### PR TITLE
Remove accidentally added solution from skeleton

### DIFF
--- a/exercises/roman-numerals/Roman.groovy
+++ b/exercises/roman-numerals/Roman.groovy
@@ -1,33 +1,7 @@
 class Roman {
   def Roman() {
     Integer.metaClass.getRoman = {->
-      def romanMappings = [
-        1000:"M",
-        900:"CM",
-        500:"D",
-        400:"CD",
-        100:"C",
-        90:"XC",
-        50:"L",
-        40:"XL",
-        10:"X",
-        9:"IX",
-        5:"V",
-        4:"IV",
-        1:"I"
-      ]
-
-      def roman = new String()
-      def num = delegate
-
-      romanMappings.each() { k, v ->
-        while (num >= k) {
-          roman += v
-          num -= k
-        }
-      }
-
-      roman
+        // RETURN the roman representation of an Integer here
     }
   }
 }


### PR DESCRIPTION
Per the discussion in [Pull request #45](https://github.com/exercism/groovy/pull/45), commit 60c6d4c3aec7d3d168fd8fa9d43ceea94250fd67 intended to include a skeleton Roman.groovy to ease the new topic of monkey patching in Groovy code.

However, I apparently went ahead and checked in the entire solution.

This commit removes the solution implementation and leaves only the skeleton code.