### PR TITLE
Ported the linked-list exercise from java

### DIFF
--- a/config.json
+++ b/config.json
@@ -180,6 +180,18 @@
       ],
       "unlocked_by": null,
       "uuid": "aa34b8a4-6958-42d4-b0ca-d846811afef1"
+    },
+    {
+      "core": true,
+      "difficulty": 6,
+      "slug": "linked-list",
+      "topics": [
+        "algorithms",
+        "generics",
+        "lists"
+      ],
+      "unlocked_by": null,
+      "uuid": "6a5e6d90-e0f3-43e7-8088-a4137bf2b125"
     }
   ],
   "foregone": [],

--- a/exercises/linked-list/DoubleLinkedList.groovy
+++ b/exercises/linked-list/DoubleLinkedList.groovy
@@ -1,0 +1,19 @@
+class DoubleLinkedList<T> {
+
+    void push(T value) {
+        throw new UnsupportedOperationException('Method implementation is missing')
+    }
+
+    T pop() {
+        throw new UnsupportedOperationException('Method implementation is missing')
+    }
+
+    T shift() {
+        throw new UnsupportedOperationException('Method implementation is missing')
+    }
+
+    void unshift(T value) {
+        throw new UnsupportedOperationException('Method implementation is missing')
+    }
+
+}

--- a/exercises/linked-list/DoubleLinkedListSpec.groovy
+++ b/exercises/linked-list/DoubleLinkedListSpec.groovy
@@ -1,0 +1,79 @@
+@Grab('org.spockframework:spock-core:1.0-groovy-2.4')
+import spock.lang.*
+
+class DoubleLinkedListSpec extends Specification {
+
+    def 'can push and pop'() {
+        DoubleLinkedList<Integer> list = new DoubleLinkedList<>()
+        when:
+            list.push(10)
+            list.push(20)
+        then:
+            list.pop() == 20
+        and:
+            list.pop() == 10
+    }
+
+    @Ignore
+    def 'can push and shift'() {
+        DoubleLinkedList<String> list = new DoubleLinkedList<>()
+        when:
+            list.push("10")
+            list.push("20")
+        then:
+            list.shift() == "10"
+        and:
+            list.shift() == "20"
+    }
+
+    @Ignore
+    def 'can unshift an shift'() {
+        DoubleLinkedList<Character> list = new DoubleLinkedList<>()
+        when:
+            list.unshift('1')
+            list.unshift('2')
+        then:
+            list.shift() == '2'
+        and:
+            list.shift() == '1'
+    }
+
+    @Ignore
+    def 'can unshift and pop'() {
+        DoubleLinkedList<Integer> list = new DoubleLinkedList<>()
+        when:
+            list.unshift(10)
+            list.unshift(20)
+        then:
+            list.pop() == 10
+        and:
+            list.pop() == 20
+    }
+
+    @Ignore
+    def 'complete example'() {
+        DoubleLinkedList<String> list = new DoubleLinkedList<>()
+        when:
+            list.push("ten")
+            list.push("twenty")
+
+        then:
+            list.pop() == "twenty"
+
+        when:
+            list.push("thirty")
+
+        then:
+            list.shift() == "ten"
+
+        when:
+            list.unshift("forty")
+            list.push("fifty")
+
+        then:
+            list.shift() == "forty"
+            list.pop() == "fifty"
+            list.shift() == "thirty"
+
+    }
+}

--- a/exercises/linked-list/Example.groovy
+++ b/exercises/linked-list/Example.groovy
@@ -1,0 +1,57 @@
+class DoubleLinkedList<T> {
+
+    Element<T> head
+
+    void push(T value) {
+        if(!head) {
+            head = new Element<>(value, null, null)
+            head.next = head
+            head.prev = head
+            return
+        }
+
+        def oldTail = head.prev
+        def tail = new Element<>(value, oldTail, head)
+        oldTail.next = tail
+        head.prev = tail
+    }
+
+    T pop() {
+        head = head.prev
+        shift()
+    }
+
+    T shift() {
+        T value = head.value
+
+        def newHead = head.next
+        def newTail = head.prev
+
+        if(newHead.is(head)) {
+            head = null
+        } else {
+            newHead.prev = newTail
+            newTail.next = newHead
+            head = newHead
+        }
+
+        value
+    }
+
+    void unshift(T value) {
+        push(value)
+        head = head.prev
+    }
+
+    private static final class Element<T> {
+        final T value
+        Element<T> prev
+        Element<T> next
+
+        Element(T value, Element<T> prev, Element<T> next) {
+            this.value = value
+            this.prev = prev
+            this.next = next
+        }
+    }
+}

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -1,0 +1,49 @@
+# Linked List
+
+Implement a doubly linked list.
+
+Like an array, a linked list is a simple linear data structure. Several
+common data types can be implemented using linked lists, like queues,
+stacks, and associative arrays.
+
+A linked list is a collection of data elements called *nodes*. In a
+*singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous
+node.
+
+You will write an implementation of a doubly linked list. Implement a
+Node to hold a value and pointers to the next and previous nodes. Then
+implement a List which holds references to the first and last node and
+offers an array-like interface for adding and removing items:
+
+* `push` (*insert value at back*);
+* `pop` (*remove value at back*);
+* `shift` (*remove value at front*).
+* `unshift` (*insert value at front*);
+
+To keep your implementation simple, the tests will not cover error
+conditions. Specifically: `pop` or `shift` will never be called on an
+empty list.
+
+If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/groovy).
+
+# Running the tests
+
+You can run all the tests for an exercise by entering
+
+```
+$ groovy ./LinkedListSpec.groovy
+```
+
+in your terminal.
+
+## Source
+
+Classic computer science topic
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
This should fix issue #85 by adding the `linked-list` exercise.

The README.md file, the tests and the example implementation have been ported and adapted from  [the Java version](https://github.com/exercism/java/tree/master/exercises/linked-list); where applicable, I tried to be as groovy-idiomatic as I could.