### PR TITLE
phone-number: Update tests to match problem specs

### DIFF
--- a/exercises/phone-number/Example.groovy
+++ b/exercises/phone-number/Example.groovy
@@ -1,20 +1,16 @@
 class PhoneNumber {
+    private static NANP_PATTERN =
+        ~/^(?:\+?1)?[-.(\s]*([2-9]\d\d)[-.)\s]*\s?([2-9]\d\d)[-.\s]*(\d{4})\s*$/
 
-    private static def REGEX = ~/^1?[\s\.\-\(]*(\d{3})[\s\.\-\)]*\s?(\d{3})[\s\.\-]*(\d{4})$/
+    final String areaCode, exchange, subscriber, number, prettyNumber
 
-    String areaCode = '000', exchange = '000', subscriber = '0000'
-
-    public PhoneNumber(String input) {
-        def matcher = REGEX.matcher(input)
-        if ( matcher.matches() ) {
-            areaCode   = "${matcher.group(1)}"
-            exchange   = "${matcher.group(2)}"
-            subscriber = "${matcher.group(3)}"
-        }
+    PhoneNumber(String input) {
+        def matcher = (input =~ NANP_PATTERN)
+        def groups = matcher ? matcher[0].tail() : ['000', '000', '0000']
+        (areaCode, exchange, subscriber) = groups
+        number = "${areaCode}${exchange}${subscriber}"
+        prettyNumber = "(${areaCode}) ${exchange}-${subscriber}"
     }
 
-    String getNumber() { "${areaCode}${exchange}${subscriber}" }
-
-    String toString() { "(${areaCode}) ${exchange}-${subscriber}" }
-
+    String toString() { prettyNumber }
 }

--- a/exercises/phone-number/PhoneNumber.groovy
+++ b/exercises/phone-number/PhoneNumber.groovy
@@ -1,17 +1,5 @@
 class PhoneNumber {
-
-    String areaCode, exchange, subscriber
-
-    public PhoneNumber(String input) {
-        throw new UnsupportedOperationException('Constructor implementation is missing')
+    PhoneNumber(String input) {
+        throw new UnsupportedOperationException('Constructor not implemented')
     }
-
-    String getNumber() {
-        throw new UnsupportedOperationException('Method implementation is missing')
-    }
-
-    String toString() {
-        throw new UnsupportedOperationException('Method implementation is missing')
-    }
-
 }

--- a/exercises/phone-number/PhoneNumberSpec.groovy
+++ b/exercises/phone-number/PhoneNumberSpec.groovy
@@ -2,74 +2,87 @@
 import spock.lang.*
 
 class PhoneNumberSpec extends Specification {
-
-    def 'a phone number is valid'() {
-        expect: new PhoneNumber('(123) 456-7890').number == '1234567890'
+    def 'cleans the number'() {
+        expect: new PhoneNumber('(223) 456-7890').number == '2234567890'
     }
 
     @Ignore
-    def 'a different phone number is valid'() {
-        expect: new PhoneNumber('(987) 654-3210').number == '9876543210'
+    def 'cleans numbers with dots'() {
+        expect: new PhoneNumber('223.456.7890').number == '2234567890'
     }
 
     @Ignore
-    def 'a phone nubmer separated by dots is valid'() {
-        expect: new PhoneNumber('456.123.7890').number == '4561237890'
+    def 'cleans numbers with multiple spaces'() {
+        expect: new PhoneNumber('223 456   7890   ').number == '2234567890'
     }
 
     @Ignore
-    def 'a letter-containing phone number is invalid'() {
-        expect: new PhoneNumber('123-abc-1234').number == '0000000000'
-    }
-
-    @Ignore
-    def 'a 9-digit number is invalid'() {
+    def 'invalid when 9 digits'() {
         expect: new PhoneNumber('123456789').number == '0000000000'
     }
 
     @Ignore
-    def 'an 11-digit number starting with a 1 is valid'() {
-        expect: new PhoneNumber('19876543210').number == '9876543210'
+    def 'invalid when 11 digits does not start with a 1'() {
+        expect: new PhoneNumber('22234567890').number == '0000000000'
     }
 
     @Ignore
-    def 'a 10-digit number, with an area code starting with 1, is valid'() {
-        expect: new PhoneNumber('1234567890').number == '1234567890'
+    def 'valid when 11 digits and starting with 1'() {
+        expect: new PhoneNumber('12234567890').number == '2234567890'
     }
 
     @Ignore
-    def 'an 11-digit number, not beginning with a 1, is invalid'(){
-        expect: new PhoneNumber('21234567890').number == '0000000000'
+    def 'valid when 11 digits and starting with 1 even with punctuation'() {
+        expect: new PhoneNumber('+1 (223) 456-7890').number == '2234567890'
     }
 
     @Ignore
-    def 'a 12-digit number, even one beginning with a 1, is invalid'(){
-        expect: new PhoneNumber('112345678901').number == '0000000000'
+    def 'invalid when more than 11 digits'() {
+        expect: new PhoneNumber('321234567890').number == '0000000000'
     }
 
     @Ignore
-    def 'a 10-digit number containing letters is inavlid'() {
-        expect: new PhoneNumber('1a2a3a4a5a6a7a8a9a0a').number == '0000000000'
+    def 'invalid with letters'() {
+        expect: new PhoneNumber('123-abc-7890').number == '0000000000'
     }
 
     @Ignore
-    def 'can extract area code from a phone number'() {
-        expect: new PhoneNumber('1234567890').areaCode == '123'
+    def 'invalid with punctuations'() {
+        expect: new PhoneNumber('123-@:!-7890').number == '0000000000'
     }
 
     @Ignore
-    def 'can extract an area code from a different phone number'() {
+    def 'invalid if area code starts with 0'() {
+        expect: new PhoneNumber('(023) 456-7890').number == '0000000000'
+    }
+
+    @Ignore
+    def 'invalid if area code starts with 1'() {
+        expect: new PhoneNumber('(123) 456-7890').number == '0000000000'
+    }
+
+    @Ignore
+    def 'invalid if exchange code starts with 0'() {
+        expect: new PhoneNumber('(223) 056-7890').number == '0000000000'
+    }
+
+    @Ignore
+    def 'invalid if exchange code starts with 1'() {
+        expect: new PhoneNumber('(223) 156-7890').number == '0000000000'
+    }
+
+    @Ignore
+    def 'can extract an area code from a phone number'() {
         expect: new PhoneNumber('9876543210').areaCode == '987'
     }
 
     @Ignore
     def 'can pretty print a phone number'() {
-        expect: new PhoneNumber('5551234567').toString() == '(555) 123-4567'
+        expect: new PhoneNumber('5552234567').toString() == '(555) 223-4567'
     }
 
     @Ignore
     def 'can pretty print a full U.S. phone number'() {
-        expect: new PhoneNumber('11234567890').toString() == '(123) 456-7890'
+        expect: new PhoneNumber('12234567890').toString() == '(223) 456-7890'
     }
-
 }

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -13,7 +13,7 @@ The format is usually represented as
 ```
 where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
 
-Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
 
 For example, the inputs
 - `+1 (613)-995-0253`


### PR DESCRIPTION
Add tests to disallow 0 and 1 as first digit of area code or exchange
and update example to pass new tests. Also, fix typo in README.md.

Resolves #110