### PR TITLE
gigasecond: Make tests valid regardless of local time zone

### DIFF
--- a/exercises/gigasecond/GigasecondSpec.groovy
+++ b/exercises/gigasecond/GigasecondSpec.groovy
@@ -8,31 +8,31 @@ class GigasecondSpec extends Specification {
 
     def 'calculates one gigasecond after a date'() {
         given:
-            def start = Date.parse('yyyy-MMM-dd', '2011-Apr-25')
+            def start = Date.parse('yyyy-MMM-dd z', '2011-Apr-25 UTC')
         when:
             def result = gigasecond.from(start)
         then:
-            result == Date.parse('yyyy-MMM-dd hh:mm:ss', '2043-Jan-01 01:46:40')
+            result == Date.parse('yyyy-MMM-dd hh:mm:ss z', '2043-Jan-01 01:46:40 UTC')
     }
 
     @Ignore
     def 'calculates one gigasecond after a date with hours and minutes'() {
         given:
-            def start = Date.parse('yyyy-MMM-dd hh:mm', '1959-Jul-19 12:31')
+            def start = Date.parse('yyyy-MMM-dd hh:mm z', '1959-Jul-19 12:31 UTC')
         when:
             def result = gigasecond.from(start)
         then:
-            result == Date.parse('yyyy-MMM-dd hh:mm:ss', '1991-Mar-27 02:17:40')
+            result == Date.parse('yyyy-MMM-dd hh:mm:ss z', '1991-Mar-27 02:17:40 UTC')
     }
 
     @Ignore
     def 'calculates one gigasecond after a date with hours and minutes and seconds'() {
         given:
-            def start = Date.parse('yyyy-MMM-dd hh:mm:ss', '1977-Jun-13 02:15:45')
+            def start = Date.parse('yyyy-MMM-dd hh:mm:ss z', '1977-Jun-13 02:15:45 UTC')
         when:
             def result = gigasecond.from(start)
         then:
-            result == Date.parse('yyyy-MMM-dd hh:mm:ss', '2009-Feb-19 04:02:25')
+            result == Date.parse('yyyy-MMM-dd hh:mm:ss z', '2009-Feb-19 04:02:25 UTC')
     }
 
 }


### PR DESCRIPTION
Some time zones that use Daylight Saving Time caused the tests
to fail even though the requirement was met.  To fix the tests
to work regardless of the machine's local time zone, force the
dates used in the test to be written in UTC.

This should fix #105 