### PR TITLE
fix: update link to sdkman install guide

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,7 +4,7 @@
 
 The preferred method of installing Groovy is [SDKman](http://sdkman.io/).
 
-Detailed instructions can be found [here](http://sdkman.io/install.html).  Breifly, open a shell and issue:
+Detailed instructions can be found [here](http://sdkman.io/install).  Breifly, open a shell and issue:
 
 1. `curl -s "https://get.sdkman.io" | bash`
 1. `source "~/.sdkman/bin/sdkman-init.sh"`


### PR DESCRIPTION
The present link for sdkman install instructions seems to be outdated and nonfunctional, so this simply updates it to a working url. 