### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -41,7 +41,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "mathematics",
         "strings"
       ]
     },
@@ -62,7 +61,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -93,7 +92,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -123,9 +122,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": [
-        "mathematics"
-      ]
+      "topics": []
     },
     {
       "slug": "word-count",
@@ -156,9 +153,7 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": [
-        "mathematics"
-      ]
+      "topics": []
     },
     {
       "slug": "scrabble-score",
@@ -167,7 +162,6 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "mathematics",
         "strings"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110