### PR TITLE
Update specs to use ||

### DIFF
--- a/exercises/allergies/src/test/groovy/AllergiesSpec.groovy
+++ b/exercises/allergies/src/test/groovy/AllergiesSpec.groovy
@@ -6,60 +6,60 @@ class AllergiesSpec extends Specification {
     Given a number and a substance, indicate whether Tom is allergic
     to that substance.
     Test cases for this method involve more than one assertion.
-    Each case in 'expected' specifies what the method should return for
+    Each case in "expected" specifies what the method should return for
     the given substance.
     */
 
-    def 'No allergies means not allergic'() {
+    def "No allergies means not allergic"() {
         given:
         int score = 0
         def allergies = new Allergies(score)
 
         expect:
-        allergies.allergicTo(substance) == result
+        allergies.allergicTo(substance) == expected
 
         where:
-        substance      | result
-        "peanuts"      | false
-        "cats"         | false
-        "strawberries" | false
+        substance      || expected
+        'peanuts'      || false
+        'cats'         || false
+        'strawberries' || false
     }
 
     @Ignore
-    def 'Is allergic to eggs'() {
+    def "Is allergic to eggs"() {
         given:
         int score = 5
         def allergies = new Allergies(score)
 
         expect:
-        allergies.allergicTo(substance) == result
+        allergies.allergicTo(substance) == expected
 
         where:
-        substance | result
-        "eggs"    | true
+        substance || expected
+        'eggs'    || true
     }
 
     @Ignore
-    def 'Allergic to strawberries but not peanuts'() {
+    def "Allergic to strawberries but not peanuts"() {
         given:
         int score = 9
         def allergies = new Allergies(score)
 
         expect:
-        allergies.allergicTo(substance) == result
+        allergies.allergicTo(substance) == expected
 
         where:
-        substance      | result
-        "eggs"         | true
-        "peanuts"      | false
-        "shellfish"    | false
-        "strawberries" | true
+        substance      || expected
+        'eggs'         || true
+        'peanuts'      || false
+        'shellfish'    || false
+        'strawberries' || true
     }
 
     // Given a number, list all things Tom is allergic to
 
     @Ignore
-    def 'No allergies at all'() {
+    def "No allergies at all"() {
         given:
         int score = 0
         def allergies = new Allergies(score)
@@ -69,90 +69,90 @@ class AllergiesSpec extends Specification {
     }
 
     @Ignore
-    def 'Allergic to just eggs'() {
+    def "Allergic to just eggs"() {
         given:
         int score = 1
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["eggs"]
+        allergies.list() == ['eggs']
     }
 
     @Ignore
-    def 'Allergic to just peanuts'() {
+    def "Allergic to just peanuts"() {
         given:
         int score = 2
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["peanuts"]
+        allergies.list() == ['peanuts']
     }
 
     @Ignore
-    def 'Allergic to just strawberries'() {
+    def "Allergic to just strawberries"() {
         given:
         int score = 8
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["strawberries"]
+        allergies.list() == ['strawberries']
     }
 
     @Ignore
-    def 'Allergic to eggs and peanuts'() {
+    def "Allergic to eggs and peanuts"() {
         given:
         int score = 3
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["eggs", "peanuts"]
+        allergies.list() == ['eggs', 'peanuts']
     }
 
     @Ignore
-    def 'Allergic to lots of stuff'() {
+    def "Allergic to lots of stuff"() {
         given:
         int score = 248
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["strawberries",
-                             "tomatoes",
-                             "chocolate",
-                             "pollen",
-                             "cats"]
+        allergies.list() == ['strawberries',
+                             'tomatoes',
+                             'chocolate',
+                             'pollen',
+                             'cats']
     }
 
     @Ignore
-    def 'Allergic to everything'() {
+    def "Allergic to everything"() {
         given:
         int score = 255
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["eggs",
-                             "peanuts",
-                             "shellfish",
-                             "strawberries",
-                             "tomatoes",
-                             "chocolate",
-                             "pollen",
-                             "cats"]
+        allergies.list() == ['eggs',
+                             'peanuts',
+                             'shellfish',
+                             'strawberries',
+                             'tomatoes',
+                             'chocolate',
+                             'pollen',
+                             'cats']
     }
 
     @Ignore
-    def 'Ignore non allergen score parts'() {
+    def "Ignore non allergen score parts"() {
         given:
         int score = 509
         def allergies = new Allergies(score)
 
         expect:
-        allergies.list() == ["eggs",
-                             "shellfish",
-                             "strawberries",
-                             "tomatoes",
-                             "chocolate",
-                             "pollen",
-                             "cats"]
+        allergies.list() == ['eggs',
+                             'shellfish',
+                             'strawberries',
+                             'tomatoes',
+                             'chocolate',
+                             'pollen',
+                             'cats']
     }
 
 }

--- a/exercises/armstrong-numbers/src/test/groovy/ArmstrongNumbersSpec.groovy
+++ b/exercises/armstrong-numbers/src/test/groovy/ArmstrongNumbersSpec.groovy
@@ -2,92 +2,92 @@ import spock.lang.*
 
 class ArmstrongNumbersSpec extends Specification {
 
-    def 'Zero is an Armstrong number'() {
+    def "Zero is an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        0      | true
+        number || expected
+        0      || true
     }
 
     @Ignore
-    def 'Single digit numbers are Armstrong numbers'() {
+    def "Single digit numbers are Armstrong numbers"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        5      | true
+        number || expected
+        5      || true
     }
 
     @Ignore
-    def 'There are no 2 digit Armstrong numbers'() {
+    def "There are no 2 digit Armstrong numbers"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        10     | false
+        number || expected
+        10     || false
     }
 
     @Ignore
-    def 'Three digit number that is an Armstrong number'() {
+    def "Three digit number that is an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        153    | true
+        number || expected
+        153    || true
     }
 
     @Ignore
-    def 'Three digit number that is not an Armstrong number'() {
+    def "Three digit number that is not an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        100    | false
+        number || expected
+        100    || false
     }
 
     @Ignore
-    def 'Four digit number that is an Armstrong number'() {
+    def "Four digit number that is an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        9474   | true
+        number || expected
+        9474   || true
     }
 
     @Ignore
-    def 'Four digit number that is not an Armstrong number'() {
+    def "Four digit number that is not an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number | result
-        9475   | false
+        number || expected
+        9475   || false
     }
 
     @Ignore
-    def 'Seven digit number that is an Armstrong number'() {
+    def "Seven digit number that is an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number  | result
-        9926315 | true
+        number  || expected
+        9926315 || true
     }
 
     @Ignore
-    def 'Seven digit number that is not an Armstrong number'() {
+    def "Seven digit number that is not an Armstrong number"() {
         expect:
-        ArmstrongNumber.isArmstrongNumber(number) == result
+        ArmstrongNumber.isArmstrongNumber(number) == expected
 
         where:
-        number  | result
-        9926314 | false
+        number  || expected
+        9926314 || false
     }
 }

--- a/exercises/atbash-cipher/src/test/groovy/AtbashCipherSpec.groovy
+++ b/exercises/atbash-cipher/src/test/groovy/AtbashCipherSpec.groovy
@@ -2,143 +2,143 @@ import spock.lang.*
 
 class AtbashCipherSpec extends Specification {
 
-    def 'encode yes'() {
+    def "Encode yes"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase | expected
-        "yes"  | "bvh"
+        phrase || expected
+        'yes'  || 'bvh'
     }
 
     @Ignore
-    def 'encode no'() {
+    def "Encode no"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase | expected
-        "no"   | "ml"
+        phrase || expected
+        'no'   || 'ml'
     }
 
     @Ignore
-    def 'encode OMG'() {
+    def "Encode OMG"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase | expected
-        "OMG"  | "lnt"
+        phrase || expected
+        'OMG'  || 'lnt'
     }
 
     @Ignore
-    def 'encode spaces'() {
+    def "Encode spaces"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase  | expected
-        "O M G" | "lnt"
+        phrase  || expected
+        'O M G' || 'lnt'
     }
 
     @Ignore
-    def 'encode mindblowingly'() {
+    def "Encode mindblowingly"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase          | expected
-        "mindblowingly" | "nrmwy oldrm tob"
+        phrase          || expected
+        'mindblowingly' || 'nrmwy oldrm tob'
     }
 
     @Ignore
-    def 'encode numbers'() {
+    def "Encode numbers"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase                    | expected
-        "Testing,1 2 3, testing." | "gvhgr mt123 gvhgr mt"
+        phrase                    || expected
+        'Testing,1 2 3, testing.' || 'gvhgr mt123 gvhgr mt'
     }
 
     @Ignore
-    def 'encode deep thought'() {
+    def "Encode deep thought"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase              | expected
-        "Truth is fiction." | "gifgs rhurx grlm"
+        phrase              || expected
+        'Truth is fiction.' || 'gifgs rhurx grlm'
     }
 
     @Ignore
-    def 'encode all the letters'() {
+    def "Encode all the letters"() {
         expect:
         AtbashCipher.encode(phrase) == expected
 
         where:
-        phrase                                         | expected
-        "The quick brown fox jumps over the lazy dog." | "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+        phrase                                         || expected
+        'The quick brown fox jumps over the lazy dog.' || 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
     }
 
     @Ignore
-    def 'decode exercism'() {
+    def "Decode exercism"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase      | expected
-        "vcvix rhn" | "exercism"
+        phrase      || expected
+        'vcvix rhn' || 'exercism'
     }
 
     @Ignore
-    def 'decode a sentence'() {
+    def "Decode a sentence"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase                                  | expected
-        "zmlyh gzxov rhlug vmzhg vkkrm thglm v" | "anobstacleisoftenasteppingstone"
+        phrase                                  || expected
+        'zmlyh gzxov rhlug vmzhg vkkrm thglm v' || 'anobstacleisoftenasteppingstone'
     }
 
     @Ignore
-    def 'decode numbers'() {
+    def "Decode numbers"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase                 | expected
-        "gvhgr mt123 gvhgr mt" | "testing123testing"
+        phrase                 || expected
+        'gvhgr mt123 gvhgr mt' || 'testing123testing'
     }
 
     @Ignore
-    def 'decode all the letters'() {
+    def "Decode all the letters"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase                                      | expected
-        "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt" | "thequickbrownfoxjumpsoverthelazydog"
+        phrase                                      || expected
+        'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt' || 'thequickbrownfoxjumpsoverthelazydog'
     }
 
     @Ignore
-    def 'decode with too many spaces'() {
+    def "Decode with too many spaces"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase           | expected
-        "vc vix    r hn" | "exercism"
+        phrase           || expected
+        'vc vix    r hn' || 'exercism'
     }
 
     @Ignore
-    def 'decode with no spaces'() {
+    def "Decode with no spaces"() {
         expect:
         AtbashCipher.decode(phrase) == expected
 
         where:
-        phrase                            | expected
-        "zmlyhgzxovrhlugvmzhgvkkrmthglmv" | "anobstacleisoftenasteppingstone"
+        phrase                            || expected
+        'zmlyhgzxovrhlugvmzhgvkkrmthglmv' || 'anobstacleisoftenasteppingstone'
 
     }
 

--- a/exercises/bank-account/src/test/groovy/BankAccountSpec.groovy
+++ b/exercises/bank-account/src/test/groovy/BankAccountSpec.groovy
@@ -2,7 +2,7 @@ import spock.lang.*
 
 class BankAccountSpec extends Specification {
 
-    def 'Newly opened account has empty balance'() {
+    def "Newly opened account has empty balance"() {
         setup:
         BankAccount account = new BankAccount()
 
@@ -14,7 +14,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Can deposit money'() {
+    def "Can deposit money"() {
         setup:
         BankAccount account = new BankAccount()
 
@@ -27,7 +27,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Can deposit money sequentially'() {
+    def "Can deposit money sequentially"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -41,7 +41,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Can withdraw money'() {
+    def "Can withdraw money"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -55,7 +55,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Can withdraw money sequentially'() {
+    def "Can withdraw money sequentially"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -70,7 +70,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot withdraw money from empty account'() {
+    def "Cannot withdraw money from empty account"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -82,7 +82,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot withdraw more money than you have'() {
+    def "Cannot withdraw more money than you have"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -96,7 +96,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot deposit negative amount'() {
+    def "Cannot deposit negative amount"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -109,7 +109,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot withdraw negative amount'() {
+    def "Cannot withdraw negative amount"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -123,7 +123,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot get balance of closed account'() {
+    def "Cannot get balance of closed account"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -138,7 +138,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot deposit money into closed account'() {
+    def "Cannot deposit money into closed account"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -152,7 +152,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Cannot withdraw money from closed account'() {
+    def "Cannot withdraw money from closed account"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -167,7 +167,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Bank account is closed before it is opened'() {
+    def "Bank account is closed before it is opened"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 
@@ -179,7 +179,7 @@ class BankAccountSpec extends Specification {
     }
 
     @Ignore
-    def 'Can adjust balance concurrently'() {
+    def "Can adjust balance concurrently"() {
         setup:
         BankAccount bankAccount = new BankAccount()
 

--- a/exercises/binary-search/src/test/groovy/BinarySearchSpec.groovy
+++ b/exercises/binary-search/src/test/groovy/BinarySearchSpec.groovy
@@ -2,113 +2,113 @@ import spock.lang.*
 
 class BinarySearchSpec extends Specification {
 
-    def 'Finds a value in an array with one element'() {
+    def "Finds a value in an array with one element"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array | value | expected
-        [6]   | 6     | 0
+        array | value || expected
+        [6]   | 6     || 0
     }
 
     @Ignore
-    def 'Finds a value in the middle of an array'() {
+    def "Finds a value in the middle of an array"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 6     | 3
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 6     || 3
     }
 
     @Ignore
-    def 'Finds a value at the beginning of an array'() {
+    def "Finds a value at the beginning of an array"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 1     | 0
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 1     || 0
     }
 
     @Ignore
-    def 'Finds a value at the end of an array'() {
+    def "Finds a value at the end of an array"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 11    | 6
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 11    || 6
     }
 
     @Ignore
-    def 'Finds a value in an array of odd length'() {
+    def "Finds a value in an array of odd length"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                                                | value | expected
-        [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634] | 144   | 9
+        array                                                | value || expected
+        [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634] | 144   || 9
     }
 
     @Ignore
-    def 'Finds a value in an array of even length'() {
+    def "Finds a value in an array of even length"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                                           | value | expected
-        [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377] | 21    | 5
+        array                                           | value || expected
+        [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377] | 21    || 5
     }
 
     @Ignore
-    def 'Identifies that a value is not included in the array'() {
+    def "Identifies that a value is not included in the array"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 7     | -1
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 7     || -1
     }
 
     @Ignore
-    def 'A value smaller than the arrays smallest value is not included'() {
+    def "A value smaller than the arrays smallest value is not included"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 0     | -1
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 0     || -1
     }
 
     @Ignore
-    def 'A value larger than the arrays largest value is not included'() {
+    def "A value larger than the arrays largest value is not included"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array                  | value | expected
-        [1, 3, 4, 6, 8, 9, 11] | 13    | -1
+        array                  | value || expected
+        [1, 3, 4, 6, 8, 9, 11] | 13    || -1
     }
 
     @Ignore
-    def 'Nothing is included in an empty array'() {
+    def "Nothing is included in an empty array"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array | value | expected
-        []    | 1     | -1
+        array | value || expected
+        []    | 1     || -1
     }
 
     @Ignore
-    def 'Nothing is found when the left and right bounds cross'() {
+    def "Nothing is found when the left and right bounds cross"() {
         expect:
         new BinarySearch(array).indexOf(value) == expected
 
         where:
-        array  | value | expected
-        [1, 2] | 0     | -1
+        array  | value || expected
+        [1, 2] | 0     || -1
     }
 
 }

--- a/exercises/collatz-conjecture/src/test/groovy/CollatzConjectureSpec.groovy
+++ b/exercises/collatz-conjecture/src/test/groovy/CollatzConjectureSpec.groovy
@@ -2,47 +2,47 @@ import spock.lang.*
 
 class CollatzConjectureSpec extends Specification {
 
-    def 'zero steps for one'() {
+    def "Zero steps for one"() {
         expect:
         CollatzConjecture.steps(number) == expected
 
         where:
-        number | expected
-        1      | 0
+        number || expected
+        1      || 0
     }
 
     @Ignore
-    def 'divide if even'() {
+    def "Divide if even"() {
         expect:
         CollatzConjecture.steps(number) == expected
 
         where:
-        number | expected
-        16     | 4
+        number || expected
+        16     || 4
     }
 
     @Ignore
-    def 'even and odd steps'() {
+    def "Even and odd steps"() {
         expect:
         CollatzConjecture.steps(number) == expected
 
         where:
-        number | expected
-        12     | 9
+        number || expected
+        12     || 9
     }
 
     @Ignore
-    def 'large number of even and odd steps'() {
+    def "Large number of even and odd steps"() {
         expect:
         CollatzConjecture.steps(number) == expected
 
         where:
-        number  | expected
-        1000000 | 152
+        number  || expected
+        1000000 || 152
     }
 
     @Ignore
-    def 'zero is an error'() {
+    def "Zero is an error"() {
         when:
         CollatzConjecture.steps(number)
 
@@ -54,7 +54,7 @@ class CollatzConjectureSpec extends Specification {
     }
 
     @Ignore
-    def 'negative value is an error'() {
+    def "Negative value is an error"() {
         when:
         CollatzConjecture.steps(number)
 

--- a/exercises/darts/src/test/groovy/DartsSpec.groovy
+++ b/exercises/darts/src/test/groovy/DartsSpec.groovy
@@ -2,72 +2,72 @@ import spock.lang.*
 
 class DartsSpec extends Specification {
 
-    def 'A dart lands outside the target'() {
+    def "A dart lands outside the target"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x  | y   | expected
-        -9 | 152 | 0
+        x  | y   || expected
+        -9 | 152 || 0
     }
 
     @Ignore
-    def 'A dart lands just in the border of the target'() {
+    def "A dart lands just in the border of the target"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x | y  | expected
-        0 | 10 | 1
+        x | y  || expected
+        0 | 10 || 1
     }
 
     @Ignore
-    def 'A dart lands in the outer circle'() {
+    def "A dart lands in the outer circle"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x | y | expected
-        4 | 4 | 1
+        x | y || expected
+        4 | 4 || 1
     }
 
     @Ignore
-    def 'A dart lands right in the border between outer and middle circles'() {
+    def "A dart lands right in the border between outer and middle circles"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x | y | expected
-        5 | 0 | 5
+        x | y || expected
+        5 | 0 || 5
     }
 
     @Ignore
-    def 'A dart lands in the middle circle'() {
+    def "A dart lands in the middle circle"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x   | y    | expected
-        0.8 | -0.8 | 5
+        x   | y    || expected
+        0.8 | -0.8 || 5
     }
 
     @Ignore
-    def 'A dart lands right in the border between middle and inner circles'() {
+    def "A dart lands right in the border between middle and inner circles"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x | y  | expected
-        0 | -1 | 10
+        x | y  || expected
+        0 | -1 || 10
     }
 
     @Ignore
-    def 'A dart lands in the inner circle'() {
+    def "A dart lands in the inner circle"() {
         expect:
         Darts.score(x, y) == expected
 
         where:
-        x    | y    | expected
-        -0.1 | -0.1 | 10
+        x    | y    || expected
+        -0.1 | -0.1 || 10
     }
 }

--- a/exercises/difference-of-squares/src/test/groovy/DifferenceOfSquaresSpec.groovy
+++ b/exercises/difference-of-squares/src/test/groovy/DifferenceOfSquaresSpec.groovy
@@ -2,41 +2,41 @@ import spock.lang.*
 
 class DifferenceOfSquaresSpec extends Specification {
 
-    @Unroll("can square the sum of the numbers up to #integer")
-    def "can square the sum up to the given integer"() {
+    @Unroll("Can square the sum of the numbers up to #integer")
+    def "Can square the sum up to the given integer"() {
         expect:
         new DifferenceOfSquares(integer).squareOfSum() == expected
 
         where:
-        integer | expected
-        1       | 1
-        5       | 225
-        100     | 25502500
+        integer || expected
+        1       || 1
+        5       || 225
+        100     || 25502500
     }
 
     @Ignore
-    @Unroll("can sum the squares up to #integer")
-    def 'can sum the squares up to the given integer'() {
+    @Unroll("Can sum the squares up to #integer")
+    def "Can sum the squares up to the given integer"() {
         expect:
         new DifferenceOfSquares(integer).sumOfSquares() == expected
 
         where:
-        integer | expected
-        1       | 1
-        5       | 55
-        100     | 338350
+        integer || expected
+        1       || 1
+        5       || 55
+        100     || 338350
     }
 
     @Ignore
-    @Unroll("can subtract sum of squares from square of sum of #integer")
-    def 'can subtract sum of squares from square of sum'() {
+    @Unroll("Can subtract sum of squares from square of sum of #integer")
+    def "Can subtract sum of squares from square of sum"() {
         expect:
         new DifferenceOfSquares(integer).difference() == expected
 
         where:
-        integer | expected
-        1       | 0
-        5       | 170
-        100     | 25164150
+        integer || expected
+        1       || 0
+        5       || 170
+        100     || 25164150
     }
 }

--- a/exercises/etl/src/test/groovy/ETLSpec.groovy
+++ b/exercises/etl/src/test/groovy/ETLSpec.groovy
@@ -2,54 +2,54 @@ import spock.lang.*
 
 class ETLSpec extends Specification {
 
-    def 'A single letter'() {
+    def "A single letter"() {
         expect:
         ETL.transform(input) == expected
 
         where:
-        input = ["1": ["A"]]
-        expected = ["a": 1]
+        input = ['1': ['A']]
+        expected = ['a': 1]
     }
 
     @Ignore
-    def 'Single score with multiple letters'() {
+    def "Single score with multiple letters"() {
         expect:
         ETL.transform(input) == expected
 
         where:
-        input = ["1": ["A", "E", "I", "O", "U"]]
-        expected = ["a": 1, "e": 1, "i": 1, "o": 1, "u": 1]
+        input = ['1': ['A', 'E', 'I', 'O', 'U']]
+        expected = ['a': 1, 'e': 1, 'i': 1, 'o': 1, 'u': 1]
     }
 
     @Ignore
-    def 'Multiple scores with multiple letters'() {
+    def "Multiple scores with multiple letters"() {
         expect:
         ETL.transform(input) == expected
 
         where:
-        input = ["1": ["A", "E"],
-                 "2": ["D", "G"]]
-        expected = ["a": 1, "d": 2, "e": 1, "g": 2]
+        input = ['1': ['A', 'E'],
+                 '2': ['D', 'G']]
+        expected = ['a': 1, 'd': 2, 'e': 1, 'g': 2]
     }
 
     @Ignore
-    def 'Multiple scores with differing numbers of letters'() {
+    def "Multiple scores with differing numbers of letters"() {
         expect:
         ETL.transform(input) == expected
 
         where:
-        input = ["1" : ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
-                 "2" : ["D", "G"],
-                 "3" : ["B", "C", "M", "P"],
-                 "4" : ["F", "H", "V", "W", "Y"],
-                 "5" : ["K"],
-                 "8" : ["J", "X"],
-                 "10": ["Q", "Z"]]
-        expected = ["a": 1, "b": 3, "c": 3, "d": 2, "e": 1,
-                    "f": 4, "g": 2, "h": 4, "i": 1, "j": 8,
-                    "k": 5, "l": 1, "m": 3, "n": 1, "o": 1,
-                    "p": 3, "q": 10, "r": 1, "s": 1, "t": 1,
-                    "u": 1, "v": 4, "w": 4, "x": 8, "y": 4,
-                    "z": 10]
+        input = ['1' : ['A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T'],
+                 '2' : ['D', 'G'],
+                 '3' : ['B', 'C', 'M', 'P'],
+                 '4' : ['F', 'H', 'V', 'W', 'Y'],
+                 '5' : ['K'],
+                 '8' : ['J', 'X'],
+                 '10': ['Q', 'Z']]
+        expected = ['a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1,
+                    'f': 4, 'g': 2, 'h': 4, 'i': 1, 'j': 8,
+                    'k': 5, 'l': 1, 'm': 3, 'n': 1, 'o': 1,
+                    'p': 3, 'q': 10, 'r': 1, 's': 1, 't': 1,
+                    'u': 1, 'v': 4, 'w': 4, 'x': 8, 'y': 4,
+                    'z': 10]
     }
 }

--- a/exercises/flatten-array/src/test/groovy/FlattenArraySpec.groovy
+++ b/exercises/flatten-array/src/test/groovy/FlattenArraySpec.groovy
@@ -5,62 +5,62 @@ class FlattenArraySpec extends Specification {
     @Shared
     def flattener = new FlattenArray()
 
-    def 'No nesting"'() {
+    def "No nesting"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array     | expected
-        [0, 1, 2] | [0, 1, 2]
+        array     || expected
+        [0, 1, 2] || [0, 1, 2]
     }
 
     @Ignore
-    def 'Flattens array with just integers present'() {
+    def "Flattens array with just integers present"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array                      | expected
-        [1, [2, 3, 4, 5, 6, 7], 8] | [1, 2, 3, 4, 5, 6, 7, 8]
+        array                      || expected
+        [1, [2, 3, 4, 5, 6, 7], 8] || [1, 2, 3, 4, 5, 6, 7, 8]
     }
 
     @Ignore
-    def '5 level nesting'() {
+    def "5 level nesting"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array                                     | expected
-        [0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2] | [0, 2, 2, 3, 8, 100, 4, 50, -2]
+        array                                     || expected
+        [0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2] || [0, 2, 2, 3, 8, 100, 4, 50, -2]
     }
 
     @Ignore
-    def '6 level nesting'() {
+    def "6 level nesting"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array                                | expected
-        [1, [2, [[3]], [4, [[5]]], 6, 7], 8] | [1, 2, 3, 4, 5, 6, 7, 8]
+        array                                || expected
+        [1, [2, [[3]], [4, [[5]]], 6, 7], 8] || [1, 2, 3, 4, 5, 6, 7, 8]
     }
 
     @Ignore
-    def '6 level nest list with null values'() {
+    def "6 level nest list with null values"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array                                            | expected
-        [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2] | [0, 2, 2, 3, 8, 100, -2]
+        array                                            || expected
+        [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2] || [0, 2, 2, 3, 8, 100, -2]
     }
 
     @Ignore
-    def 'All values in nested list are null'() {
+    def "All values in nested list are null"() {
         expect:
         flattener.flatten(array) == expected
 
         where:
-        array                                                      | expected
-        [null, [[[null]]], null, null, [[null, null], null], null] | []
+        array                                                      || expected
+        [null, [[[null]]], null, null, [[null, null], null], null] || []
     }
 }

--- a/exercises/gigasecond/src/test/groovy/GigasecondSpec.groovy
+++ b/exercises/gigasecond/src/test/groovy/GigasecondSpec.groovy
@@ -9,7 +9,7 @@ class GigasecondSpec extends Specification {
     @Shared
     def gigasecond = new Gigasecond()
 
-    def 'date only specification of time'() {
+    def "Date only specification of time"() {
         expect:
         expected == gigasecond.add(moment)
 
@@ -19,7 +19,7 @@ class GigasecondSpec extends Specification {
     }
 
     @Ignore
-    def 'second test for date only specification of time'() {
+    def "Second test for date only specification of time"() {
         expect:
         expected == gigasecond.add(moment)
 
@@ -29,7 +29,7 @@ class GigasecondSpec extends Specification {
     }
 
     @Ignore
-    def 'third test for date only specification of time'() {
+    def "Third test for date only specification of time"() {
         expect:
         expected == gigasecond.add(moment)
 
@@ -39,7 +39,7 @@ class GigasecondSpec extends Specification {
     }
 
     @Ignore
-    def 'full time specified'() {
+    def "Full time specified"() {
         expect:
         expected == gigasecond.add(moment)
 
@@ -49,7 +49,7 @@ class GigasecondSpec extends Specification {
     }
 
     @Ignore
-    def 'full time with day roll-over'() {
+    def "Full time with day roll-over"() {
         expect:
         expected == gigasecond.add(moment)
 

--- a/exercises/grains/src/test/groovy/GrainsSpec.groovy
+++ b/exercises/grains/src/test/groovy/GrainsSpec.groovy
@@ -5,77 +5,77 @@ class GrainsSpec extends Specification {
     @Shared
     def grains = new Grains()
 
-    def 'Square of 1'() {
+    def "Square of 1"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        1      | 1
+        square || expected
+        1      || 1
     }
 
     @Ignore
-    def 'Square of 2'() {
+    def "Square of 2"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        2      | 2
+        square || expected
+        2      || 2
     }
 
     @Ignore
-    def 'Square of 3'() {
+    def "Square of 3"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        3      | 4
+        square || expected
+        3      || 4
     }
 
     @Ignore
-    def 'Square of 4'() {
+    def "Square of 4"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        4      | 8
+        square || expected
+        4      || 8
     }
 
     @Ignore
-    def 'Square of 16'() {
+    def "Square of 16"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        16     | 32768
+        square || expected
+        16     || 32768
     }
 
     @Ignore
-    def 'Square of 32'() {
+    def "Square of 32"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        32     | 2147483648
+        square || expected
+        32     || 2147483648
     }
 
     @Ignore
-    def 'Square of 64'() {
+    def "Square of 64"() {
         expect:
         grains.square(square) == expected
 
         where:
-        square | expected
-        64     | 9223372036854775808
+        square || expected
+        64     || 9223372036854775808
     }
 
     @Ignore
-    def 'Test total'() {
+    def "Test total"() {
         expect:
         grains.total() == 18446744073709551615
     }

--- a/exercises/hamming/src/test/groovy/HammingSpec.groovy
+++ b/exercises/hamming/src/test/groovy/HammingSpec.groovy
@@ -5,56 +5,57 @@ class HammingSpec extends Specification {
     @Shared
     def hamming = new Hamming()
 
-    def 'empty strands'() {
+    def "Empty strands"() {
         expect:
         hamming.distance(strand1, strand2) == expected
 
         where:
-        strand1 | strand2 | expected
-        ""      | ""      | 0
-    }
-
-    def 'single letter identical strands'() {
-        expect:
-        hamming.distance(strand1, strand2) == expected
-
-        where:
-        strand1 | strand2 | expected
-        "A"     | "A"     | 0
+        strand1 | strand2 || expected
+        ''      | ''      || 0
     }
 
     @Ignore
-    def 'single letter different strands'() {
+    def "Single letter identical strands"() {
         expect:
         hamming.distance(strand1, strand2) == expected
 
         where:
-        strand1 | strand2 | expected
-        "G"     | "T"     | 1
+        strand1 | strand2 || expected
+        'A'     | 'A'     || 0
     }
 
     @Ignore
-    def 'long identical strands'() {
+    def "Single letter different strands"() {
         expect:
         hamming.distance(strand1, strand2) == expected
 
         where:
-        strand1         | strand2         | expected
-        "GGACTGAAATCTG" | "GGACTGAAATCTG" | 0
+        strand1 | strand2 || expected
+        'G'     | 'T'     || 1
     }
 
     @Ignore
-    def 'long different strands'() {
+    def "Long identical strands"() {
         expect:
         hamming.distance(strand1, strand2) == expected
 
         where:
-        strand1        | strand2        | expected
-        "GGACGGATTCTG" | "AGGACGGATTCT" | 9
+        strand1         | strand2         || expected
+        'GGACTGAAATCTG' | 'GGACTGAAATCTG' || 0
     }
 
     @Ignore
-    def 'disallow first strand longer'() {
+    def "Long different strands"() {
+        expect:
+        hamming.distance(strand1, strand2) == expected
+
+        where:
+        strand1        | strand2        || expected
+        'GGACGGATTCTG' | 'AGGACGGATTCT' || 9
+    }
+
+    @Ignore
+    def "Disallow first strand longer"() {
         when:
         hamming.distance(strand1, strand2)
 
@@ -63,11 +64,11 @@ class HammingSpec extends Specification {
 
         where:
         strand1 | strand2
-        "AATG"  | "AAA"
+        'AATG'  | 'AAA'
     }
 
     @Ignore
-    def 'disallow second strand longer'() {
+    def "Disallow second strand longer"() {
         when:
         hamming.distance(strand1, strand2)
 
@@ -76,11 +77,11 @@ class HammingSpec extends Specification {
 
         where:
         strand1 | strand2
-        "ATA"   | "AGTG"
+        'ATA'   | 'AGTG'
     }
 
     @Ignore
-    def 'disallow left empty strand'() {
+    def "Disallow left empty strand"() {
         when:
         hamming.distance(strand1, strand2)
 
@@ -89,11 +90,11 @@ class HammingSpec extends Specification {
 
         where:
         strand1 | strand2
-        ""      | "G"
+        ''      | 'G'
     }
 
     @Ignore
-    def 'disallow right empty strand'() {
+    def "Disallow right empty strand"() {
         when:
         hamming.distance(strand1, strand2)
 
@@ -102,7 +103,7 @@ class HammingSpec extends Specification {
 
         where:
         strand1 | strand2
-        "G"     | ""
+        'G'     | ''
     }
 
 }

--- a/exercises/hello-world/src/test/groovy/HelloWorldSpec.groovy
+++ b/exercises/hello-world/src/test/groovy/HelloWorldSpec.groovy
@@ -2,12 +2,12 @@ import spock.lang.*
 
 class HelloWorldSpec extends Specification {
 
-    def 'outputs "Hello, World!"'() {
+    def "Outputs 'Hello, World!'"() {
         expect:
         new HelloWorld().hello() == expected
 
         where:
-        expected = "Hello, World!"
+        expected = 'Hello, World!'
     }
 
 }

--- a/exercises/isbn-verifier/src/test/groovy/IsbnVerifierSpec.groovy
+++ b/exercises/isbn-verifier/src/test/groovy/IsbnVerifierSpec.groovy
@@ -2,172 +2,172 @@ import spock.lang.*
 
 class IsbnVerifierSpec extends Specification {
 
-    def 'Valid isbn number'() {
+    def "Valid isbn number"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-21508-8" | true
+        isbn            || expected
+        '3-598-21508-8' || true
     }
 
     @Ignore
-    def 'Invalid isbn check digit'() {
+    def "Invalid isbn check digit"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-21508-9" | false
+        isbn            || expected
+        '3-598-21508-9' || false
     }
 
     @Ignore
-    def 'Valid isbn number with a check digit of 10'() {
+    def "Valid isbn number with a check digit of 10"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-21507-X" | true
+        isbn            || expected
+        '3-598-21507-X' || true
     }
 
     @Ignore
-    def 'Check digit is a character other than X'() {
+    def "Check digit is a character other than X"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-21507-A" | false
+        isbn            || expected
+        '3-598-21507-A' || false
     }
 
     @Ignore
-    def 'Invalid character in isbn'() {
+    def "Invalid character in isbn"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-P1581-X" | false
+        isbn            || expected
+        '3-598-P1581-X' || false
     }
 
     @Ignore
-    def 'X is only valid as a check digit'() {
+    def "X is only valid as a check digit"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-2X507-9" | false
+        isbn            || expected
+        '3-598-2X507-9' || false
     }
 
     @Ignore
-    def 'Valid isbn without separating dashes'() {
+    def "Valid isbn without separating dashes"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn         | expected
-        "3598215088" | true
+        isbn         || expected
+        '3598215088' || true
     }
 
     @Ignore
-    def 'Isbn without separating dashes and X as check digit'() {
+    def "Isbn without separating dashes and X as check digit"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn         | expected
-        "359821507X" | true
+        isbn         || expected
+        '359821507X' || true
     }
 
     @Ignore
-    def 'Isbn without check digit and dashes'() {
+    def "Isbn without check digit and dashes"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn        | expected
-        "359821507" | false
+        isbn        || expected
+        '359821507' || false
     }
 
     @Ignore
-    def 'Too long isbn and no dashes'() {
+    def "Too long isbn and no dashes"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn        | expected
-        "359821507" | false
+        isbn        || expected
+        '359821507' || false
     }
 
     @Ignore
-    def 'Too short isbn'() {
+    def "Too short isbn"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn | expected
-        "00" | false
+        isbn || expected
+        '00' || false
     }
 
     @Ignore
-    def 'Isbn without check digit'() {
+    def "Isbn without check digit"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn          | expected
-        "3-598-21507" | false
+        isbn          || expected
+        '3-598-21507' || false
     }
 
     @Ignore
-    def 'Check digit of X should not be used for 0'() {
+    def "Check digit of X should not be used for 0"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn            | expected
-        "3-598-21515-X" | false
+        isbn            || expected
+        '3-598-21515-X' || false
     }
 
     @Ignore
-    def 'Empty isbn'() {
+    def "Empty isbn"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn | expected
-        ""   | false
+        isbn || expected
+        ''   || false
     }
 
     @Ignore
-    def 'Input is 9 characters'() {
+    def "Input is 9 characters"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn        | expected
-        "134456729" | false
+        isbn        || expected
+        '134456729' || false
     }
 
     @Ignore
-    def 'Invalid characters are not ignored'() {
+    def "Invalid characters are not ignored"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn         | expected
-        "3132P34035" | false
+        isbn         || expected
+        '3132P34035' || false
     }
 
     @Ignore
-    def 'Input is too long but contains a valid isbn'() {
+    def "Input is too long but contains a valid isbn"() {
         expect:
         IsbnVerifier.isValid(isbn) == expected
 
         where:
-        isbn          | expected
-        "98245726788" | false
+        isbn          || expected
+        '98245726788' || false
     }
 }

--- a/exercises/isogram/src/test/groovy/IsogramSpec.groovy
+++ b/exercises/isogram/src/test/groovy/IsogramSpec.groovy
@@ -2,123 +2,123 @@ import spock.lang.*
 
 class IsogramSpec extends Specification {
 
-    def 'An empty string'() {
+    def "An empty string"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase | expected
-        ""     | true
+        phrase || expected
+        ''     || true
     }
 
     @Ignore
-    def 'Isogram with only lower case characters'() {
+    def "Isogram with only lower case characters"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase    | expected
-        "isogram" | true
+        phrase    || expected
+        'isogram' || true
     }
 
     @Ignore
-    def 'Word with one duplicated character'() {
+    def "Word with one duplicated character"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase   | expected
-        "eleven" | false
+        phrase   || expected
+        'eleven' || false
     }
 
     @Ignore
-    def 'Word with one duplicated character from the end of the alphabet'() {
+    def "Word with one duplicated character from the end of the alphabet"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase  | expected
-        "zzyzx" | false
+        phrase  || expected
+        'zzyzx' || false
     }
 
     @Ignore
-    def 'Longest reported english isogram'() {
+    def "Longest reported english isogram"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase              | expected
-        "subdermatoglyphic" | true
+        phrase              || expected
+        'subdermatoglyphic' || true
     }
 
     @Ignore
-    def 'Word with duplicated character in mixed case'() {
+    def "Word with duplicated character in mixed case"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase     | expected
-        "Alphabet" | false
+        phrase     || expected
+        'Alphabet' || false
     }
 
     @Ignore
-    def 'Hypothetical isogrammic word with hyphen'() {
+    def "Hypothetical isogrammic word with hyphen"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase                | expected
-        "thumbscrew-japingly" | true
+        phrase                || expected
+        'thumbscrew-japingly' || true
     }
 
     @Ignore
-    def 'Hypothetical word with duplicated character following hyphen'() {
+    def "Hypothetical word with duplicated character following hyphen"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase                 | expected
-        "thumbscrew-jappingly" | false
+        phrase                 || expected
+        'thumbscrew-jappingly' || false
     }
 
     @Ignore
-    def 'Isogram with duplicated hyphen'() {
+    def "Isogram with duplicated hyphen"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase         | expected
-        "six-year-old" | true
+        phrase         || expected
+        'six-year-old' || true
     }
 
     @Ignore
-    def 'Made-up name that is an isogram'() {
+    def "Made-up name that is an isogram"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase                    | expected
-        "Emily Jung Schwartzkopf" | true
+        phrase                    || expected
+        'Emily Jung Schwartzkopf' || true
     }
 
     @Ignore
-    def 'Duplicated character in the middle'() {
+    def "Duplicated character in the middle"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase     | expected
-        "accentor" | false
+        phrase     || expected
+        'accentor' || false
     }
 
     @Ignore
-    def 'Same first and last characters'() {
+    def "Same first and last characters"() {
         expect:
         Isogram.isIsogram(phrase) == expected
 
         where:
-        phrase   | expected
-        "angola" | false
+        phrase   || expected
+        'angola' || false
     }
 
 }

--- a/exercises/leap/src/test/groovy/LeapSpec.groovy
+++ b/exercises/leap/src/test/groovy/LeapSpec.groovy
@@ -2,63 +2,63 @@ import spock.lang.*
 
 class LeapSpec extends Specification {
 
-    def 'Year not divisible by 4 in common year'() {
+    def "Year not divisible by 4 in common year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        2015 | false
+        year || expected
+        2015 || false
     }
 
     @Ignore
-    def 'Year divisible by 2, not divisible by 4 in common year'() {
+    def "Year divisible by 2, not divisible by 4 in common year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        1970 | false
+        year || expected
+        1970 || false
     }
 
     @Ignore
-    def 'Year divisible by 4, not divisible by 100 in leap year'() {
+    def "Year divisible by 4, not divisible by 100 in leap year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        1996 | true
+        year || expected
+        1996 || true
     }
 
     @Ignore
-    def 'Year divisible by 100, not divisible by 400 in common year'() {
+    def "Year divisible by 100, not divisible by 400 in common year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        2100 | false
+        year || expected
+        2100 || false
     }
 
     @Ignore
-    def 'Year divisible by 400 in leap year'() {
+    def "Year divisible by 400 in leap year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        2000 | true
+        year || expected
+        2000 || true
     }
 
     @Ignore
-    def 'Year divisible by 200, not divisible by 400 in common year'() {
+    def "Year divisible by 200, not divisible by 400 in common year"() {
         expect:
         new Leap(year).isLeapYear() == expected
 
         where:
-        year | expected
-        1800 | false
+        year || expected
+        1800 || false
     }
 
 }

--- a/exercises/linked-list/src/test/groovy/DoubleLinkedListSpec.groovy
+++ b/exercises/linked-list/src/test/groovy/DoubleLinkedListSpec.groovy
@@ -2,7 +2,7 @@ import spock.lang.*
 
 class DoubleLinkedListSpec extends Specification {
 
-    def 'Can push and pop'() {
+    def "Can push and pop"() {
         DoubleLinkedList<Integer> list = new DoubleLinkedList<>()
 
         when:
@@ -17,22 +17,22 @@ class DoubleLinkedListSpec extends Specification {
     }
 
     @Ignore
-    def 'Can push and shift'() {
+    def "Can push and shift"() {
         DoubleLinkedList<String> list = new DoubleLinkedList<>()
 
         when:
-        list.push("10")
-        list.push("20")
+        list.push('10')
+        list.push('20')
 
         then:
-        list.shift() == "10"
+        list.shift() == '10'
 
         and:
-        list.shift() == "20"
+        list.shift() == '20'
     }
 
     @Ignore
-    def 'Can unshift an shift'() {
+    def "Can unshift an shift"() {
         DoubleLinkedList<Character> list = new DoubleLinkedList<>()
 
         when:
@@ -47,7 +47,7 @@ class DoubleLinkedListSpec extends Specification {
     }
 
     @Ignore
-    def 'Can unshift and pop'() {
+    def "Can unshift and pop"() {
         DoubleLinkedList<Integer> list = new DoubleLinkedList<>()
 
         when:
@@ -62,29 +62,29 @@ class DoubleLinkedListSpec extends Specification {
     }
 
     @Ignore
-    def 'Complete example'() {
+    def "Complete example"() {
         DoubleLinkedList<String> list = new DoubleLinkedList<>()
 
         when:
-        list.push("ten")
-        list.push("twenty")
+        list.push('ten')
+        list.push('twenty')
 
         then:
-        list.pop() == "twenty"
+        list.pop() == 'twenty'
 
         when:
-        list.push("thirty")
+        list.push('thirty')
 
         then:
-        list.shift() == "ten"
+        list.shift() == 'ten'
 
         when:
-        list.unshift("forty")
-        list.push("fifty")
+        list.unshift('forty')
+        list.push('fifty')
 
         then:
-        list.shift() == "forty"
-        list.pop() == "fifty"
-        list.shift() == "thirty"
+        list.shift() == 'forty'
+        list.pop() == 'fifty'
+        list.shift() == 'thirty'
     }
 }

--- a/exercises/luhn/src/test/groovy/LuhnSpec.groovy
+++ b/exercises/luhn/src/test/groovy/LuhnSpec.groovy
@@ -3,164 +3,163 @@ import spock.lang.Specification
 
 class LuhnSpec extends Specification {
 
-    def 'Single digit strings can not be valid'() {
+    def "Single digit strings can not be valid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        "1"   | false
+        value || expected
+        '1'   || false
     }
 
     @Ignore
-    def 'A single zero is invalid'() {
+    def "A single zero is invalid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        "0"   | false
+        value || expected
+        '0'   || false
     }
 
     @Ignore
-    def 'A simple valid SIN that remains valid if reversed'() {
+    def "A simple valid SIN that remains valid if reversed"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        "059" | true
+        value || expected
+        '059' || true
     }
 
     @Ignore
-    def 'A simple valid SIN that becomes invalid if reversed'() {
+    def "A simple valid SIN that becomes invalid if reversed"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        "59"  | true
+        value || expected
+        '59'  || true
     }
 
     @Ignore
-    def 'A valid Canadian SIN'() {
+    def "A valid Canadian SIN"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value         | expected
-        "055 444 285" | true
+        value         || expected
+        '055 444 285' || true
     }
 
     @Ignore
-    def 'Invalid Canadian SIN'() {
+    def "Invalid Canadian SIN"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value         | expected
-        "055 444 286" | false
+        value         || expected
+        '055 444 286' || false
     }
 
     @Ignore
-    def 'Invalid credit card'() {
+    def "Invalid credit card"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value                 | expected
-        "8273 1232 7352 0569" | false
+        value                 || expected
+        '8273 1232 7352 0569' || false
     }
 
     @Ignore
-    def 'Valid number with an even number of digits'() {
+    def "Valid number with an even number of digits"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value        | expected
-        "095 245 88" | true
+        value        || expected
+        '095 245 88' || true
     }
 
     @Ignore
-    def 'Valid strings with a non-digit added at the end become invalid'() {
+    def "Valid strings with a non-digit added at the end become invalid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value  | expected
-        "059a" | false
+        value  || expected
+        '059a' || false
     }
 
     @Ignore
-    def 'Valid strings with punctuation included become invalid'() {
+    def "Valid strings with punctuation included become invalid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value         | expected
-        "055-444-285" | false
+        value         || expected
+        '055-444-285' || false
     }
 
     @Ignore
-    def 'Valid strings with symbols included become invalid'() {
+    def "Valid strings with symbols included become invalid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value            | expected
-        "055£ 444\$ 285" | false
+        value            || expected
+        '055£ 444\$ 285' || false
     }
 
     @Ignore
-    def 'Single zero with space is invalid'() {
+    def "Single zero with space is invalid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        " 0"  | false
+        value || expected
+        ' 0'  || false
     }
 
     @Ignore
-    def 'More than a single zero is valid'() {
+    def "More than a single zero is valid"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value    | expected
-        "0000 0" | true
+        value    || expected
+        '0000 0' || true
     }
 
     @Ignore
-    def 'Input digit 9 is correctly converted to output digit 9'() {
+    def "Input digit 9 is correctly converted to output digit 9"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        "091" | true
+        value || expected
+        '091' || true
     }
 
     @Ignore
-    def 'Using ascii value for non-doubled non-digit isn\'t allowed'() {
+    def "Using ascii value for non-doubled non-digit isn't allowed"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value          | expected
-        "055b 444 285" | false
+        value          || expected
+        '055b 444 285' || false
     }
 
     @Ignore
-    def 'Using ascii value for doubled non-digit isn\'t allowed'() {
+    def "Using ascii value for doubled non-digit isn't allowed"() {
         expect:
         Luhn.valid(value) == expected
 
         where:
-        value | expected
-        ":9"  | false
+        value || expected
+        ':9'  || false
     }
-
 
 }

--- a/exercises/matrix/src/test/groovy/MatrixSpec.groovy
+++ b/exercises/matrix/src/test/groovy/MatrixSpec.groovy
@@ -2,82 +2,82 @@ import spock.lang.*
 
 class MatrixSpec extends Specification {
 
-    def 'Extract row from one number matrix'() {
+    def "Extract row from one number matrix"() {
         expect:
         new Matrix(string).row(index) == expected
 
         where:
-        string | index | expected
-        "1"    | 0     | [1]
+        string | index || expected
+        '1'    | 0     || [1]
     }
 
     @Ignore
-    def 'Can extract row'() {
+    def "Can extract row"() {
         expect:
         new Matrix(string).row(index) == expected
 
         where:
-        string     | index | expected
-        "1 2\n3 4" | 1     | [3, 4]
+        string     | index || expected
+        '1 2\n3 4' | 1     || [3, 4]
     }
 
     @Ignore
-    def 'Extract row where numbers have different widths'() {
+    def "Extract row where numbers have different widths"() {
         expect:
         new Matrix(string).row(index) == expected
 
         where:
-        string       | index | expected
-        "1 2\n10 20" | 1     | [10, 20]
+        string       | index || expected
+        '1 2\n10 20' | 1     || [10, 20]
     }
 
     @Ignore
-    def 'Can extract row from non-square matrix'() {
+    def "Can extract row from non-square matrix"() {
         expect:
         new Matrix(string).row(index) == expected
 
         where:
-        string                       | index | expected
-        "1 2 3\n4 5 6\n7 8 9\n8 7 6" | 2     | [7, 8, 9]
+        string                       | index || expected
+        '1 2 3\n4 5 6\n7 8 9\n8 7 6' | 2     || [7, 8, 9]
     }
 
     @Ignore
-    def 'Extract column from one number matrix'() {
+    def "Extract column from one number matrix"() {
         expect:
         new Matrix(string).row(index) == expected
 
         where:
-        string | index | expected
-        "1"    | 0     | [1]
+        string | index || expected
+        '1'    | 0     || [1]
     }
 
     @Ignore
-    def 'Can extract column'() {
+    def "Can extract column"() {
         expect:
         new Matrix(string).column(index) == expected
 
         where:
-        string                | index | expected
-        "1 2 3\n4 5 6\n7 8 9" | 2     | [3, 6, 9]
+        string                | index || expected
+        '1 2 3\n4 5 6\n7 8 9' | 2     || [3, 6, 9]
     }
 
     @Ignore
-    def 'Can extract column from non-square matrix'() {
+    def "Can extract column from non-square matrix"() {
         expect:
         new Matrix(string).column(index) == expected
 
         where:
-        string                       | index | expected
-        "1 2 3\n4 5 6\n7 8 9\n8 7 6" | 2     | [3, 6, 9, 6]
+        string                       | index || expected
+        '1 2 3\n4 5 6\n7 8 9\n8 7 6' | 2     || [3, 6, 9, 6]
     }
 
     @Ignore
-    def 'Extract column where numbers have different widths'() {
+    def "Extract column where numbers have different widths"() {
         expect:
         new Matrix(string).column(index) == expected
 
         where:
-        string                       | index | expected
-        "89 1903 3\n18 3 1\n9 4 800" | 1     | [1903, 3, 4]
+        string                       | index || expected
+        '89 1903 3\n18 3 1\n9 4 800' | 1     || [1903, 3, 4]
     }
 }

--- a/exercises/nth-prime/src/test/groovy/NthPrimeSpec.groovy
+++ b/exercises/nth-prime/src/test/groovy/NthPrimeSpec.groovy
@@ -2,47 +2,47 @@ import spock.lang.*
 
 class NthPrimeSpec extends Specification {
 
-    def 'Can calculate the first prime'() {
+    def "Can calculate the first prime"() {
         expect:
         NthPrime.nth(number) == expected
 
         where:
-        number | expected
-        1      | 2
+        number || expected
+        1      || 2
     }
 
     @Ignore
-    def 'Can calculate the second prime'() {
+    def "Can calculate the second prime"() {
         expect:
         NthPrime.nth(number) == expected
 
         where:
-        number | expected
-        2      | 3
+        number || expected
+        2      || 3
     }
 
     @Ignore
-    def 'Can calculate the sixth prime'() {
+    def "Can calculate the sixth prime"() {
         expect:
         NthPrime.nth(number) == expected
 
         where:
-        number | expected
-        6      | 13
+        number || expected
+        6      || 13
     }
 
     @Ignore
-    def 'Can calculate a big prime'() {
+    def "Can calculate a big prime"() {
         expect:
         NthPrime.nth(number) == expected
 
         where:
-        number | expected
-        10001  | 104743
+        number || expected
+        10001  || 104743
     }
 
     @Ignore
-    def 'throws exception when asked for the zeroth prime'() {
+    def "Throws exception when asked for the zeroth prime"() {
         when:
         NthPrime.nth(0)
 

--- a/exercises/nucleotide-count/src/test/groovy/NucleotideCountSpec.groovy
+++ b/exercises/nucleotide-count/src/test/groovy/NucleotideCountSpec.groovy
@@ -2,49 +2,49 @@ import spock.lang.*
 
 class NucleotideCountSpec extends Specification {
 
-    def 'Empty strand'() {
+    def "Empty strand"() {
         expect:
         NucleotideCount.count(strand) == expected
 
         where:
-        strand | expected
-        ""     | ["A": 0, "C": 0, "G": 0, "T": 0]
+        strand || expected
+        ''     || ['A': 0, 'C': 0, 'G': 0, 'T': 0]
     }
 
     @Ignore
-    def 'Can count one nucleotide in single-character input'() {
+    def "Can count one nucleotide in single-character input"() {
         expect:
         NucleotideCount.count(strand) == expected
 
         where:
-        strand | expected
-        "G"    | ["A": 0, "C": 0, "G": 1, "T": 0]
+        strand || expected
+        'G'    || ['A': 0, 'C': 0, 'G': 1, 'T': 0]
     }
 
     @Ignore
-    def 'Strand with repeated nucleotide'() {
+    def "Strand with repeated nucleotide"() {
         expect:
         NucleotideCount.count(strand) == expected
 
         where:
-        strand    | expected
-        "GGGGGGG" | ["A": 0, "C": 0, "G": 7, "T": 0]
+        strand    || expected
+        'GGGGGGG' || ['A': 0, 'C': 0, 'G': 7, 'T': 0]
     }
 
     @Ignore
-    def 'Strand with multiple nucleotides'() {
+    def "Strand with multiple nucleotides"() {
         expect:
         NucleotideCount.count(strand) == expected
 
         where:
-        strand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
-        expected = ["A": 20, "C": 12, "G": 17, "T": 21]
+        strand = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+        expected = ['A': 20, 'C': 12, 'G': 17, 'T': 21]
     }
 
     @Ignore
-    def 'Strand with invalid nucleotides'() {
+    def "Strand with invalid nucleotides"() {
         when:
-        NucleotideCount.count("AGXXACT")
+        NucleotideCount.count('AGXXACT')
 
         then:
         thrown(ArithmeticException)

--- a/exercises/pangram/src/test/groovy/PangramSpec.groovy
+++ b/exercises/pangram/src/test/groovy/PangramSpec.groovy
@@ -2,103 +2,103 @@ import spock.lang.*
 
 class PangramSpec extends Specification {
 
-    def 'Sentence empty'() {
+    def "Sentence empty"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence | expected
-        ""       | false
+        sentence || expected
+        ''       || false
     }
 
     @Ignore
-    def 'Recognizes a perfect lower case pangram'() {
+    def "Recognizes a perfect lower case pangram"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                     | expected
-        "abcdefghijklmnopqrstuvwxyz" | true
+        sentence                     || expected
+        'abcdefghijklmnopqrstuvwxyz' || true
     }
 
     @Ignore
-    def 'Pangram with only lower case'() {
+    def "Pangram with only lower case"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                      | expected
-        "the quick brown fox jumps over the lazy dog" | true
+        sentence                                      || expected
+        'the quick brown fox jumps over the lazy dog' || true
     }
 
     @Ignore
-    def 'Missing character \'x\''() {
+    def "Missing character 'x'"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                                      | expected
-        "a quick movement of the enemy will jeopardize five gunboats" | false
+        sentence                                                      || expected
+        'a quick movement of the enemy will jeopardize five gunboats' || false
     }
 
     @Ignore
-    def 'Another missing character, e.g. \'h\''() {
+    def "Another missing character, e.g. 'h'"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                 | expected
-        "five boxing wizards jump quickly at it" | false
+        sentence                                 || expected
+        'five boxing wizards jump quickly at it' || false
     }
 
     @Ignore
-    def 'Pangram with underscores'() {
+    def "Pangram with underscores"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                      | expected
-        "the_quick_brown_fox_jumps_over_the_lazy_dog" | true
+        sentence                                      || expected
+        'the_quick_brown_fox_jumps_over_the_lazy_dog' || true
     }
 
     @Ignore
-    def 'Pangram with numbers'() {
+    def "Pangram with numbers"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                           | expected
-        "the 1 quick brown fox jumps over the 2 lazy dogs" | true
+        sentence                                           || expected
+        'the 1 quick brown fox jumps over the 2 lazy dogs' || true
     }
 
     @Ignore
-    def 'Missing letters replaced by numbers'() {
+    def "Missing letters replaced by numbers"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                      | expected
-        "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog" | false
+        sentence                                      || expected
+        '7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog' || false
     }
 
     @Ignore
-    def 'Pangram with mixed case and punctuation'() {
+    def "Pangram with mixed case and punctuation"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                     | expected
-        "\"Five quacking Zephyrs jolt my wax bed.\"" | true
+        sentence                                   || expected
+        '"Five quacking Zephyrs jolt my wax bed."' || true
     }
 
     @Ignore
-    def 'Upper and lower case versions of the same character should not be counted separately'() {
+    def "Upper and lower case versions of the same character should not be counted separately"() {
         expect:
         Pangram.isPangram(sentence) == expected
 
         where:
-        sentence                                      | expected
-        "the quick brown fox jumps over with lazy FX" | false
+        sentence                                      || expected
+        'the quick brown fox jumps over with lazy FX' || false
     }
 
 }

--- a/exercises/phone-number/src/test/groovy/PhoneNumberSpec.groovy
+++ b/exercises/phone-number/src/test/groovy/PhoneNumberSpec.groovy
@@ -1,172 +1,172 @@
 import spock.lang.*
 
 class PhoneNumberSpec extends Specification {
-    def 'Cleans the number'() {
+    def "Cleans the number"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase           | expected
-        "(223) 456-7890" | "2234567890"
+        phrase           || expected
+        '(223) 456-7890' || '2234567890'
     }
 
     @Ignore
-    def 'Cleans numbers with dots'() {
+    def "Cleans numbers with dots"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase         | expected
-        "223.456.7890" | "2234567890"
+        phrase         || expected
+        '223.456.7890' || '2234567890'
     }
 
     @Ignore
-    def 'Cleans numbers with multiple spaces'() {
+    def "Cleans numbers with multiple spaces"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase              | expected
-        "223 456   7890   " | "2234567890"
+        phrase              || expected
+        '223 456   7890   ' || '2234567890'
     }
 
     @Ignore
-    def 'invalid when 9 digits'() {
+    def "invalid when 9 digits"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase      | expected
-        "123456789" | "0000000000"
+        phrase      || expected
+        '123456789' || '0000000000'
     }
 
     @Ignore
-    def 'invalid when 11 digits does not start with a 1'() {
+    def "invalid when 11 digits does not start with a 1"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase        | expected
-        "22234567890" | "0000000000"
+        phrase        || expected
+        '22234567890' || '0000000000'
     }
 
     @Ignore
-    def 'valid when 11 digits and starting with 1'() {
+    def "valid when 11 digits and starting with 1"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase        | expected
-        "12234567890" | "2234567890"
+        phrase        || expected
+        '12234567890' || '2234567890'
     }
 
     @Ignore
-    def 'valid when 11 digits and starting with 1 even with punctuation'() {
+    def "valid when 11 digits and starting with 1 even with punctuation"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase              | expected
-        "+1 (223) 456-7890" | "2234567890"
+        phrase              || expected
+        '+1 (223) 456-7890' || '2234567890'
     }
 
     @Ignore
-    def 'invalid when more than 11 digits'() {
+    def "invalid when more than 11 digits"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase         | expected
-        "321234567890" | "0000000000"
+        phrase         || expected
+        '321234567890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid with letters'() {
+    def "invalid with letters"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase         | expected
-        "123-abc-7890" | "0000000000"
+        phrase         || expected
+        '123-abc-7890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid with punctuations'() {
+    def "invalid with punctuations"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase         | expected
-        "123-@:!-7890" | "0000000000"
+        phrase         || expected
+        '123-@:!-7890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid if area code starts with 0'() {
+    def "invalid if area code starts with 0"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase           | expected
-        "(023) 456-7890" | "0000000000"
+        phrase           || expected
+        '(023) 456-7890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid if area code starts with 1'() {
+    def "invalid if area code starts with 1"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase           | expected
-        "(123) 456-7890" | "0000000000"
+        phrase           || expected
+        '(123) 456-7890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid if exchange code starts with 0'() {
+    def "invalid if exchange code starts with 0"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase           | expected
-        "(223) 056-7890" | "0000000000"
+        phrase           || expected
+        '(223) 056-7890' || '0000000000'
     }
 
     @Ignore
-    def 'invalid if exchange code starts with 1'() {
+    def "invalid if exchange code starts with 1"() {
         expect:
         new PhoneNumber(phrase).number == expected
 
         where:
-        phrase           | expected
-        "(223) 156-7890" | "0000000000"
+        phrase           || expected
+        '(223) 156-7890' || '0000000000'
     }
 
     @Ignore
-    def 'Can extract an area code from a phone number'() {
+    def "Can extract an area code from a phone number"() {
         expect:
         new PhoneNumber(phrase).areaCode == expected
 
         where:
-        phrase       | expected
-        "9876543210" | "987"
+        phrase       || expected
+        '9876543210' || '987'
     }
 
     @Ignore
-    def 'Can pretty print a phone number'() {
+    def "Can pretty print a phone number"() {
         expect:
         new PhoneNumber(phrase).toString() == expected
 
         where:
-        phrase       | expected
-        "5552234567" | "(555) 223-4567"
+        phrase       || expected
+        '5552234567' || "(555) 223-4567"
     }
 
     @Ignore
-    def 'Can pretty print a full U.S. phone number'() {
+    def "Can pretty print a full U.S. phone number"() {
         expect:
         new PhoneNumber(phrase).toString() == expected
 
         where:
-        phrase        | expected
-        "12234567890" | "(223) 456-7890"
+        phrase        || expected
+        '12234567890' || "(223) 456-7890"
     }
 }

--- a/exercises/raindrops/src/test/groovy/RaindropsSpec.groovy
+++ b/exercises/raindrops/src/test/groovy/RaindropsSpec.groovy
@@ -5,183 +5,183 @@ class RaindropsSpec extends Specification {
     @Shared
     def raindrops = new Raindrops()
 
-    def '1 returns 1'() {
+    def "1 returns 1"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        1      | "1"
+        number || expected
+        1      || '1'
     }
 
     @Ignore
-    def '3, being divisible by 3, returns "Pling"'() {
+    def "3, being divisible by 3, returns 'Pling'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        3      | "Pling"
+        number || expected
+        3      || 'Pling'
     }
 
     @Ignore
-    def '5, divisible by 5, returns "Plang"'() {
+    def "5, divisible by 5, returns 'Plang'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        5      | "Plang"
+        number || expected
+        5      || 'Plang'
     }
 
     @Ignore
-    def '7, divisible by 7, returns "Plong"'() {
+    def "7, divisible by 7, returns 'Plong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        7      | "Plong"
+        number || expected
+        7      || 'Plong'
     }
 
     @Ignore
-    def '6, divisible by 3, returns "Pling"'() {
+    def "6, divisible by 3, returns 'Pling'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        6      | "Pling"
+        number || expected
+        6      || 'Pling'
     }
 
     @Ignore
-    def '8 returns the string "8"'() {
+    def "8 returns the string '8'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        8      | "8"
+        number || expected
+        8      || '8'
     }
 
     @Ignore
-    def '9, divisible by 3, returns "Pling"'() {
+    def "9, divisible by 3, returns 'Pling'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        9      | "Pling"
+        number || expected
+        9      || 'Pling'
     }
 
     @Ignore
-    def '10, divisible by 5, returns "Plang"'() {
+    def "10, divisible by 5, returns 'Plang'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        10     | "Plang"
+        number || expected
+        10     || 'Plang'
     }
 
     @Ignore
-    def '14, divisible by 7, returns "Plong"'() {
+    def "14, divisible by 7, returns 'Plong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        14     | "Plong"
+        number || expected
+        14     || 'Plong'
     }
 
     @Ignore
-    def '15, divisible by both 3 and 5, returns "PlingPlang"'() {
+    def "15, divisible by both 3 and 5, returns 'PlingPlang'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        15     | "PlingPlang"
+        number || expected
+        15     || 'PlingPlang'
     }
 
     @Ignore
-    def '21, divisible by 3 and 7, returns "PlingPlong"'() {
+    def "21, divisible by 3 and 7, returns 'PlingPlong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        21     | "PlingPlong"
+        number || expected
+        21     || 'PlingPlong'
     }
 
     @Ignore
-    def '25, divisible by 5, returns "Plang"'() {
+    def "25, divisible by 5, returns 'Plang'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        25     | "Plang"
+        number || expected
+        25     || 'Plang'
     }
 
     @Ignore
-    def '27, divisible by 3, returns "Pling"'() {
+    def "27, divisible by 3, returns 'Pling'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        27     | "Pling"
+        number || expected
+        27     || 'Pling'
     }
 
     @Ignore
-    def '35, divisible by 5 and 7, returns "PlangPlong"'() {
+    def "35, divisible by 5 and 7, returns 'PlangPlong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        35     | "PlangPlong"
+        number || expected
+        35     || 'PlangPlong'
     }
 
     @Ignore
-    def '49, divisible by 7, returns "Plong"'() {
+    def "49, divisible by 7, returns 'Plong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        49     | "Plong"
+        number || expected
+        49     || 'Plong'
     }
 
     @Ignore
-    def '52 returns the string "52"'() {
+    def "52 returns the string '52'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        52     | "52"
+        number || expected
+        52     || '52'
     }
 
     @Ignore
-    def '105 returns "PlingPlangPlong"'() {
+    def "105 returns 'PlingPlangPlong'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        105    | "PlingPlangPlong"
+        number || expected
+        105    || 'PlingPlangPlong'
     }
 
     @Ignore
-    def '3125, divisible by 5, returns "Plang"'() {
+    def "3125, divisible by 5, returns 'Plang'"() {
         expect:
         raindrops.convert(number) == expected
 
         where:
-        number | expected
-        3125   | "Plang"
+        number || expected
+        3125   || 'Plang'
     }
 
 }

--- a/exercises/resistor-color-duo/src/test/groovy/ResistorColorDuoSpec.groovy
+++ b/exercises/resistor-color-duo/src/test/groovy/ResistorColorDuoSpec.groovy
@@ -2,42 +2,42 @@ import spock.lang.*
 
 class ResistorColorDuoSpec extends Specification {
 
-    def 'Brown and black'() {
+    def "Brown and black"() {
         expect:
         ResistorColorDuo.value(colors) == expected
 
         where:
-        colors             | expected
-        ["brown", "black"] | 10
+        colors             || expected
+        ['brown', 'black'] || 10
     }
 
     @Ignore
-    def 'Blue and grey'() {
+    def "Blue and grey"() {
         expect:
         ResistorColorDuo.value(colors) == expected
 
         where:
-        colors           | expected
-        ["blue", "grey"] | 68
+        colors           || expected
+        ['blue', 'grey'] || 68
     }
 
     @Ignore
-    def 'Yellow and violet'() {
+    def "Yellow and violet"() {
         expect:
         ResistorColorDuo.value(colors) == expected
 
         where:
-        colors               | expected
-        ["yellow", "violet"] | 47
+        colors               || expected
+        ['yellow', 'violet'] || 47
     }
 
     @Ignore
-    def 'Orange and orange'() {
+    def "Orange and orange"() {
         expect:
         ResistorColorDuo.value(colors) == expected
 
         where:
-        colors               | expected
-        ["orange", "orange"] | 33
+        colors               || expected
+        ['orange', 'orange'] || 33
     }
 }

--- a/exercises/resistor-color/src/test/groovy/ResistorColorSpec.groovy
+++ b/exercises/resistor-color/src/test/groovy/ResistorColorSpec.groovy
@@ -3,29 +3,29 @@ import spock.lang.*
 class ResistorColorSpec extends Specification {
 
     @Unroll
-    def '#color'() {
+    def "#color"() {
         expect:
-        ResistorColor.colorCode(color) == result
+        ResistorColor.colorCode(color) == expected
 
         where:
-        color    | result
-        "black"  | 0
-        "white"  | 9
-        "orange" | 3
+        color    || expected
+        'black'  || 0
+        'white'  || 9
+        'orange' || 3
     }
 
     @Ignore
-    def 'Colors'() {
+    def "Colors"() {
         expect:
-        ResistorColor.colors == ["black",
-                                 "brown",
-                                 "red",
-                                 "orange",
-                                 "yellow",
-                                 "green",
-                                 "blue",
-                                 "violet",
-                                 "grey",
-                                 "white"]
+        ResistorColor.colors == ['black',
+                                 'brown',
+                                 'red',
+                                 'orange',
+                                 'yellow',
+                                 'green',
+                                 'blue',
+                                 'violet',
+                                 'grey',
+                                 'white']
     }
 }

--- a/exercises/reverse-string/src/test/groovy/ReverseStringSpec.groovy
+++ b/exercises/reverse-string/src/test/groovy/ReverseStringSpec.groovy
@@ -2,52 +2,52 @@ import spock.lang.*
 
 class ReverseStringSpec extends Specification {
 
-    def 'An empty string'() {
+    def "An empty string"() {
         expect:
         ReverseString.reverse(value) == expected
 
         where:
-        value | expected
-        ""    | ""
+        value || expected
+        ''    || ''
     }
 
     @Ignore
-    def 'A word'() {
+    def "A word"() {
         expect:
         ReverseString.reverse(value) == expected
 
         where:
-        value   | expected
-        "robot" | "tobor"
+        value   || expected
+        'robot' || 'tobor'
     }
 
     @Ignore
-    def 'A capitalized word'() {
+    def "A capitalized word"() {
         expect:
         ReverseString.reverse(value) == expected
 
         where:
-        value   | expected
-        "Ramen" | "nemaR"
+        value   || expected
+        'Ramen' || 'nemaR'
     }
 
     @Ignore
-    def 'A sentence with punctuation'() {
+    def "A sentence with punctuation"() {
         expect:
         ReverseString.reverse(value) == expected
 
         where:
-        value         | expected
-        "I'm hungry!" | "!yrgnuh m'I"
+        value         || expected
+        "I'm hungry!" || "!yrgnuh m'I"
     }
 
     @Ignore
-    def 'A palindrome'() {
+    def "A palindrome"() {
         expect:
         ReverseString.reverse(value) == expected
 
         where:
-        value     | expected
-        "racecar" | "racecar"
+        value     || expected
+        'racecar' || 'racecar'
     }
 }

--- a/exercises/rna-transcription/src/test/groovy/RnaTranscriptionSpec.groovy
+++ b/exercises/rna-transcription/src/test/groovy/RnaTranscriptionSpec.groovy
@@ -5,57 +5,57 @@ class RnaTranscriptionSpec extends Specification {
     @Shared
     def complement = new RnaTranscription()
 
-    def 'The RNA complement of cytosine is guanine'() {
+    def "The RNA complement of cytosine is guanine"() {
         expect:
         complement.ofDNA(dna) == expected
 
         where:
-        dna | expected
-        "C" | "G"
+        dna || expected
+        'C' || 'G'
     }
 
     @Ignore
-    def 'The RNA complement of guanine is cytosine'() {
+    def "The RNA complement of guanine is cytosine"() {
         expect:
         complement.ofDNA(dna) == expected
 
         where:
-        dna | expected
-        "G" | "C"
+        dna || expected
+        'G' || 'C'
     }
 
     @Ignore
-    def 'The RNA complement of thymine is adenine'() {
+    def "The RNA complement of thymine is adenine"() {
         expect:
         complement.ofDNA(dna) == expected
 
         where:
-        dna | expected
-        "T" | "A"
+        dna || expected
+        'T' || 'A'
     }
 
     @Ignore
-    def 'The RNA complement of adenine is uracil'() {
+    def "The RNA complement of adenine is uracil"() {
         expect:
         complement.ofDNA(dna) == expected
 
         where:
-        dna | expected
-        "A" | "U"
+        dna || expected
+        'A' || 'U'
     }
 
     @Ignore
-    def 'Can calculate long strand complement'() {
+    def "Can calculate long strand complement"() {
         expect:
         complement.ofDNA(dna) == expected
 
         where:
-        dna            | expected
-        "ACGTGGTCTTAA" | "UGCACCAGAAUU"
+        dna            || expected
+        'ACGTGGTCTTAA' || 'UGCACCAGAAUU'
     }
 
     @Ignore
-    def 'Correctly handles invalid input'() {
+    def "Correctly handles invalid input"() {
         when:
         complement.ofDNA('U')
 
@@ -64,7 +64,7 @@ class RnaTranscriptionSpec extends Specification {
     }
 
     @Ignore
-    def 'Correctly handles completely invalid input'() {
+    def "Correctly handles completely invalid input"() {
         when:
         complement.ofDNA('XXX')
 
@@ -73,7 +73,7 @@ class RnaTranscriptionSpec extends Specification {
     }
 
     @Ignore
-    def 'Correctly handles partially invalid input'() {
+    def "Correctly handles partially invalid input"() {
         when:
         complement.ofDNA('ACGTXXXCTTAA')
 

--- a/exercises/robot-name/src/test/groovy/RobotNameSpec.groovy
+++ b/exercises/robot-name/src/test/groovy/RobotNameSpec.groovy
@@ -2,13 +2,13 @@ import spock.lang.*
 
 class RobotNameSpec extends Specification {
 
-    def 'generates a name'() {
+    def "Generates a name"() {
         expect:
         new RobotName().name =~ /^[a-zA-Z]{2}\d{3}$/
     }
 
     @Ignore
-    def 'generates the same name when called again'() {
+    def "Generates the same name when called again"() {
         given:
         def robot = new RobotName()
 
@@ -17,7 +17,7 @@ class RobotNameSpec extends Specification {
     }
 
     @Ignore
-    def 'different robots generate different names'() {
+    def "Different robots generate different names"() {
         given:
         def robot = new RobotName()
         def other_robot = new RobotName()
@@ -27,7 +27,7 @@ class RobotNameSpec extends Specification {
     }
 
     @Ignore
-    def 'can be reset to generate another name'() {
+    def "Can be reset to generate another name"() {
         given:
         def robot = new RobotName()
         def name_before_reset = robot.name

--- a/exercises/roman-numerals/src/test/groovy/RomanNumeralsSpec.groovy
+++ b/exercises/roman-numerals/src/test/groovy/RomanNumeralsSpec.groovy
@@ -6,30 +6,30 @@ class RomanNumeralsSpec extends Specification {
     def setup() { new RomanNumerals() }
 
     @Unroll
-    def "can convert arabic #arabic to roman #roman"() {
+    def "Can convert arabic #arabic to roman #expected"() {
         expect:
-        arabic.roman == roman
+        arabic.roman == expected
 
         where:
-        arabic | roman
-        1      | 'I'
-        2      | 'II'
-        3      | 'III'
-        4      | 'IV'
-        5      | 'V'
-        6      | 'VI'
-        9      | 'IX'
-        27     | 'XXVII'
-        48     | 'XLVIII'
-        59     | 'LIX'
-        93     | 'XCIII'
-        141    | 'CXLI'
-        163    | 'CLXIII'
-        402    | 'CDII'
-        575    | 'DLXXV'
-        911    | 'CMXI'
-        1024   | 'MXXIV'
-        3000   | 'MMM'
+        arabic || expected
+        1      || 'I'
+        2      || 'II'
+        3      || 'III'
+        4      || 'IV'
+        5      || 'V'
+        6      || 'VI'
+        9      || 'IX'
+        27     || 'XXVII'
+        48     || 'XLVIII'
+        59     || 'LIX'
+        93     || 'XCIII'
+        141    || 'CXLI'
+        163    || 'CLXIII'
+        402    || 'CDII'
+        575    || 'DLXXV'
+        911    || 'CMXI'
+        1024   || 'MXXIV'
+        3000   || 'MMM'
     }
 
 }

--- a/exercises/rotational-cipher/src/test/groovy/RotationalCipherSpec.groovy
+++ b/exercises/rotational-cipher/src/test/groovy/RotationalCipherSpec.groovy
@@ -3,103 +3,103 @@ import spock.lang.*
 class RotationalCipherSpec extends Specification {
 
 
-    def 'Rotate a by 0, same output as input'() {
+    def "Rotate a by 0, same output as input"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text | expected
-        0        | "a"  | "a"
+        shiftKey | text || expected
+        0        | 'a'  || 'a'
     }
 
     @Ignore
-    def 'Rotate a by 1'() {
+    def "Rotate a by 1"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text | expected
-        1        | "a"  | "b"
+        shiftKey | text || expected
+        1        | 'a'  || 'b'
     }
 
     @Ignore
-    def 'Rotate a by 26, same output as input'() {
+    def "Rotate a by 26, same output as input"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text | expected
-        26       | "a"  | "a"
+        shiftKey | text || expected
+        26       | 'a'  || 'a'
     }
 
     @Ignore
-    def 'Rotate m by 13'() {
+    def "Rotate m by 13"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text | expected
-        13       | "m"  | "z"
+        shiftKey | text || expected
+        13       | 'm'  || 'z'
     }
 
     @Ignore
-    def 'Rotate n by 13 with wrap around alphabet'() {
+    def "Rotate n by 13 with wrap around alphabet"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text | expected
-        13       | "n"  | "a"
+        shiftKey | text || expected
+        13       | 'n'  || 'a'
     }
 
     @Ignore
-    def 'Rotate capital letters'() {
+    def "Rotate capital letters"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text  | expected
-        5        | "OMG" | "TRL"
+        shiftKey | text  || expected
+        5        | 'OMG' || 'TRL'
     }
 
     @Ignore
-    def 'Rotate spaces'() {
+    def "Rotate spaces"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text    | expected
-        5        | "O M G" | "T R L"
+        shiftKey | text    || expected
+        5        | 'O M G' || 'T R L'
     }
 
     @Ignore
-    def 'Rotate numbers'() {
+    def "Rotate numbers"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text                    | expected
-        4        | "Testing 1 2 3 testing" | "Xiwxmrk 1 2 3 xiwxmrk"
+        shiftKey | text                    || expected
+        4        | 'Testing 1 2 3 testing' || 'Xiwxmrk 1 2 3 xiwxmrk'
     }
 
     @Ignore
-    def 'Rotate punctuation'() {
+    def "Rotate punctuation"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text                  | expected
-        21       | "Let's eat, Grandma!" | "Gzo'n zvo, Bmviyhv!"
+        shiftKey | text                  || expected
+        21       | "Let's eat, Grandma!" || "Gzo'n zvo, Bmviyhv!"
     }
 
     @Ignore
-    def 'Rotate all letters'() {
+    def "Rotate all letters"() {
         expect:
         new RotationalCipher(shiftKey).rotate(text) == expected
 
         where:
-        shiftKey | text                                           | expected
-        13       | "Gur dhvpx oebja sbk whzcf bire gur ynml qbt." | "The quick brown fox jumps over the lazy dog."
+        shiftKey | text                                           || expected
+        13       | 'Gur dhvpx oebja sbk whzcf bire gur ynml qbt.' || 'The quick brown fox jumps over the lazy dog.'
     }
 
 }

--- a/exercises/saddle-points/src/test/groovy/SaddlePointsSpec.groovy
+++ b/exercises/saddle-points/src/test/groovy/SaddlePointsSpec.groovy
@@ -2,7 +2,7 @@ import spock.lang.*
 
 class SaddlePointsSpec extends Specification {
 
-    def 'Can identify single saddle point'() {
+    def "Can identify single saddle point"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -16,7 +16,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify that empty matrix has no saddle points'() {
+    def "Can identify that empty matrix has no saddle points"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -26,7 +26,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify lack of saddle points when there are none'() {
+    def "Can identify lack of saddle points when there are none"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -40,7 +40,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify multiple saddle points in a column'() {
+    def "Can identify multiple saddle points in a column"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -56,7 +56,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify multiple saddle points in a row'() {
+    def "Can identify multiple saddle points in a row"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -72,7 +72,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify saddle point in bottom right corner'() {
+    def "Can identify saddle point in bottom right corner"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -86,7 +86,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify saddle points in a non square matrix'() {
+    def "Can identify saddle points in a non square matrix"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -101,7 +101,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify that saddle points in a single column matrix are those with the minimum value'() {
+    def "Can identify that saddle points in a single column matrix are those with the minimum value"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 
@@ -118,7 +118,7 @@ class SaddlePointsSpec extends Specification {
     }
 
     @Ignore
-    def 'Can identify that saddle points in a single row matrix are those with the maximum value'() {
+    def "Can identify that saddle points in a single row matrix are those with the maximum value"() {
         expect:
         SaddlePoints.getSaddlePoints(matrix) == expected
 

--- a/exercises/scrabble-score/src/test/groovy/ScrabbleScoreSpec.groovy
+++ b/exercises/scrabble-score/src/test/groovy/ScrabbleScoreSpec.groovy
@@ -2,60 +2,60 @@ import spock.lang.*
 
 class ScrabbleScoreSpec extends Specification {
 
-    def 'Lowercase letter'() {
+    def "Lowercase letter"() {
         expect:
         ScrabbleScore.scoreWord(word) == expected
 
         where:
-        word | expected
-        "a"  | 1
+        word || expected
+        'a'  || 1
     }
 
     @Ignore
-    def 'Uppercase letter'() {
+    def "Uppercase letter"() {
         expect:
         ScrabbleScore.scoreWord(word) == expected
 
         where:
-        word | expected
-        "A"  | 1
+        word || expected
+        'A'  || 1
     }
 
     @Ignore
-    def 'Valuable letter'() {
+    def "Valuable letter"() {
         expect:
         ScrabbleScore.scoreWord(word) == expected
 
         where:
-        word | expected
-        "f"  | 4
+        word || expected
+        'f'  || 4
     }
 
     @Ignore
-    def 'Empty input'() {
+    def "Empty input"() {
         expect:
         ScrabbleScore.scoreWord(word) == expected
 
         where:
-        word | expected
-        ""   | 0
+        word || expected
+        ''   || 0
     }
 
     @Unroll
     @Ignore
-    def 'Score for word #word should be #expected'() {
+    def "Score for word #word should be #expected"() {
         expect:
         ScrabbleScore.scoreWord(word) == expected
 
         where:
-        word                         | expected
-        'at'                         | 2
-        'zoo'                        | 12
-        'street'                     | 6
-        'quirky'                     | 22
-        'OxyphenButazone'            | 41
-        'pinata'                     | 8
-        'abcdefghijklmnopqrstuvwxyz' | 87
+        word                         || expected
+        'at'                         || 2
+        'zoo'                        || 12
+        'street'                     || 6
+        'quirky'                     || 22
+        'OxyphenButazone'            || 41
+        'pinata'                     || 8
+        'abcdefghijklmnopqrstuvwxyz' || 87
     }
 
 }

--- a/exercises/secret-handshake/src/test/groovy/SecretHandshakeSpec.groovy
+++ b/exercises/secret-handshake/src/test/groovy/SecretHandshakeSpec.groovy
@@ -2,113 +2,113 @@ import spock.lang.*
 
 class SecretHandshakeSpec extends Specification {
 
-    def 'Wink for 1'() {
+    def "Wink for 1"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        1      | ['wink']
+        number || expected
+        1      || ['wink']
     }
 
     @Ignore
-    def 'Double blink for 10'() {
+    def "Double blink for 10"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        2      | ['double blink']
+        number || expected
+        2      || ['double blink']
     }
 
     @Ignore
-    def 'Close your eyes for 100'() {
+    def "Close your eyes for 100"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        4      | ['close your eyes']
+        number || expected
+        4      || ['close your eyes']
     }
 
     @Ignore
-    def 'Jump for 1000'() {
+    def "Jump for 1000"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        8      | ['jump']
+        number || expected
+        8      || ["jump"]
     }
 
     @Ignore
-    def 'Combine two actions'() {
+    def "Combine two actions"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        3      | ['wink', 'double blink']
+        number || expected
+        3      || ['wink', 'double blink']
     }
 
     @Ignore
-    def 'Reverse two actions'() {
+    def "Reverse two actions"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        19     | ['double blink', 'wink']
+        number || expected
+        19     || ['double blink', 'wink']
     }
 
     @Ignore
-    def 'Reversing one action gives the same action'() {
+    def "Reversing one action gives the same action"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        24     | ['jump']
+        number || expected
+        24     || ['jump']
     }
 
     @Ignore
-    def 'Reversing no actions still gives no actions'() {
+    def "Reversing no actions still gives no actions"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        16     | []
+        number || expected
+        16     || []
     }
 
     @Ignore
-    def 'All possible actions'() {
+    def "All possible actions"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        15     | ['wink', 'double blink', 'close your eyes', 'jump']
+        number || expected
+        15     || ['wink', 'double blink', 'close your eyes', 'jump']
     }
 
     @Ignore
-    def 'Reverse all possible actions'() {
+    def "Reverse all possible actions"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        31     | ['jump', 'close your eyes', 'double blink', 'wink']
+        number || expected
+        31     || ['jump', 'close your eyes', 'double blink', 'wink']
     }
 
     @Ignore
-    def 'Do nothing for zero'() {
+    def "Do nothing for zero"() {
         expect:
         SecretHandshake.commands(number) == expected
 
         where:
-        number | expected
-        0      | []
+        number || expected
+        0      || []
     }
 
 }

--- a/exercises/space-age/src/test/groovy/SpaceAgeSpec.groovy
+++ b/exercises/space-age/src/test/groovy/SpaceAgeSpec.groovy
@@ -2,83 +2,83 @@ import spock.lang.*
 
 class SpaceAgeSpec extends Specification {
 
-    def 'Age on Earth'() {
+    def "Age on Earth"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet  | seconds    | expected
-        "Earth" | 1000000000 | 31.69
+        planet  | seconds    || expected
+        'Earth' | 1000000000 || 31.69
     }
 
     @Ignore
-    def 'Age on Mercury'() {
+    def "Age on Mercury"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet    | seconds    | expected
-        "Mercury" | 2134835688 | 280.88
+        planet    | seconds    || expected
+        'Mercury' | 2134835688 || 280.88
     }
 
     @Ignore
-    def 'Age on Venus'() {
+    def "Age on Venus"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet  | seconds   | expected
-        "Venus" | 189839836 | 9.78
+        planet  | seconds   || expected
+        'Venus' | 189839836 || 9.78
     }
 
     @Ignore
-    def 'Age on Mars'() {
+    def "Age on Mars"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet | seconds    | expected
-        "Mars" | 2129871239 | 35.88
+        planet | seconds    || expected
+        'Mars' | 2129871239 || 35.88
     }
 
     @Ignore
-    def 'Age on Jupiter'() {
+    def "Age on Jupiter"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet    | seconds   | expected
-        "Jupiter" | 901876382 | 2.41
+        planet    | seconds   || expected
+        'Jupiter' | 901876382 || 2.41
     }
 
     @Ignore
-    def 'Age on Saturn'() {
+    def "Age on Saturn"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet   | seconds    | expected
-        "Saturn" | 2000000000 | 2.15
+        planet   | seconds    || expected
+        'Saturn' | 2000000000 || 2.15
     }
 
     @Ignore
-    def 'Age on Uranus'() {
+    def "Age on Uranus"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet   | seconds    | expected
-        "Uranus" | 1210123456 | 0.46
+        planet   | seconds    || expected
+        'Uranus' | 1210123456 || 0.46
     }
 
     @Ignore
-    def 'Age on Neptune'() {
+    def "Age on Neptune"() {
         expect:
         SpaceAge.age(planet, seconds) == expected
 
         where:
-        planet    | seconds    | expected
-        "Neptune" | 1821023456 | 0.35
+        planet    | seconds    || expected
+        'Neptune' | 1821023456 || 0.35
     }
 
 }

--- a/exercises/sum-of-multiples/src/test/groovy/SumOfMultiplesSpec.groovy
+++ b/exercises/sum-of-multiples/src/test/groovy/SumOfMultiplesSpec.groovy
@@ -2,162 +2,162 @@ import spock.lang.*
 
 class SumOfMultiplesSpec extends Specification {
 
-    def 'No multiples within limit'() {
+    def "No multiples within limit"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 5]  | 1     | 0
+        factors | limit || expected
+        [3, 5]  | 1     || 0
     }
 
     @Ignore
-    def 'One factor has multiples within limit'() {
+    def "One factor has multiples within limit"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 5]  | 4     | 3
+        factors | limit || expected
+        [3, 5]  | 4     || 3
     }
 
     @Ignore
-    def 'More than one multiple within limit'() {
+    def "More than one multiple within limit"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3]     | 7     | 9
+        factors | limit || expected
+        [3]     | 7     || 9
     }
 
     @Ignore
-    def 'More than one factor with multiples within limit'() {
+    def "More than one factor with multiples within limit"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 5]  | 10    | 23
+        factors | limit || expected
+        [3, 5]  | 10    || 23
     }
 
     @Ignore
-    def 'Each multiple is only counted once'() {
+    def "Each multiple is only counted once"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 5]  | 100   | 2318
+        factors | limit || expected
+        [3, 5]  | 100   || 2318
     }
 
     @Ignore
-    def 'A much larger limit'() {
+    def "A much larger limit"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 5]  | 1000  | 233168
+        factors | limit || expected
+        [3, 5]  | 1000  || 233168
     }
 
     @Ignore
-    def 'Three factors'() {
+    def "Three factors"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors     | limit | expected
-        [7, 13, 17] | 20    | 51
+        factors     | limit || expected
+        [7, 13, 17] | 20    || 51
     }
 
     @Ignore
-    def 'Factors not relatively prime'() {
+    def "Factors not relatively prime"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [4, 6]  | 15    | 30
+        factors | limit || expected
+        [4, 6]  | 15    || 30
     }
 
     @Ignore
-    def 'Some pairs of factors relatively prime and some not'() {
+    def "Some pairs of factors relatively prime and some not"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors   | limit | expected
-        [5, 6, 8] | 150   | 4419
+        factors   | limit || expected
+        [5, 6, 8] | 150   || 4419
     }
 
     @Ignore
-    def 'One factor is a multiple of another'() {
+    def "One factor is a multiple of another"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [5, 25] | 51    | 275
+        factors | limit || expected
+        [5, 25] | 51    || 275
     }
 
     @Ignore
-    def 'Much larger factors'() {
+    def "Much larger factors"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors  | limit | expected
-        [43, 47] | 10000 | 2203160
+        factors  | limit || expected
+        [43, 47] | 10000 || 2203160
     }
 
     @Ignore
-    def 'All numbers are multiples of 1'() {
+    def "All numbers are multiples of 1"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [1]     | 100   | 4950
+        factors | limit || expected
+        [1]     | 100   || 4950
     }
 
     @Ignore
-    def 'No factors means an empty sum'() {
+    def "No factors means an empty sum"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [0]     | 10000 | 0
+        factors | limit || expected
+        [0]     | 10000 || 0
     }
 
     @Ignore
-    def 'The only multiple of 0 is 0'() {
+    def "The only multiple of 0 is 0"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [0]     | 1     | 0
+        factors | limit || expected
+        [0]     | 1     || 0
     }
 
     @Ignore
-    def 'The factor 0 does not affect the sum of multiples of other factors'() {
+    def "The factor 0 does not affect the sum of multiples of other factors"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors | limit | expected
-        [3, 0]  | 4     | 3
+        factors | limit || expected
+        [3, 0]  | 4     || 3
     }
 
     @Ignore
-    def 'Solutions using include-exclude must extend to cardinality greater than 3'() {
+    def "Solutions using include-exclude must extend to cardinality greater than 3"() {
         expect:
         SumOfMultiples.sum(factors, limit) == expected
 
         where:
-        factors          | limit | expected
-        [2, 3, 5, 7, 11] | 10000 | 39614537
+        factors          | limit || expected
+        [2, 3, 5, 7, 11] | 10000 || 39614537
     }
 }

--- a/exercises/triangle/src/test/groovy/TriangleSpec.groovy
+++ b/exercises/triangle/src/test/groovy/TriangleSpec.groovy
@@ -2,193 +2,193 @@ import spock.lang.*
 
 class TriangleSpec extends Specification {
 
-    def 'All sides are equal'() {
+    def "All sides are equal for equilateral"() {
         expect:
         Triangle.isEquilateral(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        2 | 2 | 2 | true
+        a | b | c || expected
+        2 | 2 | 2 || true
     }
 
     @Ignore
-    def 'Any side is unequal'() {
+    def "Any side is unequal"() {
         expect:
         Triangle.isEquilateral(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        2 | 3 | 2 | false
+        a | b | c || expected
+        2 | 3 | 2 || false
     }
 
     @Ignore
-    def 'No sides are equal'() {
+    def "No sides are equal for equilateral"() {
         expect:
         Triangle.isEquilateral(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        5 | 4 | 6 | false
+        a | b | c || expected
+        5 | 4 | 6 || false
     }
 
     @Ignore
-    def 'All zero sides is not a triangle'() {
+    def "All zero sides is not a triangle"() {
         expect:
         Triangle.isEquilateral(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        0 | 0 | 0 | false
+        a | b | c || expected
+        0 | 0 | 0 || false
     }
 
     @Ignore
-    def 'Sides may be floats'() {
+    def "Sides may be floats for equilateral"() {
         expect:
         Triangle.isEquilateral(a, b, c) == expected
 
         where:
-        a   | b   | c   | expected
-        0.5 | 0.5 | 0.5 | true
+        a   | b   | c   || expected
+        0.5 | 0.5 | 0.5 || true
     }
 
     @Ignore
-    def 'Last two sides are equal'() {
+    def "Last two sides are equal"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        3 | 4 | 4 | true
+        a | b | c || expected
+        3 | 4 | 4 || true
     }
 
     @Ignore
-    def 'First two sides are equal'() {
+    def "First two sides are equal"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        4 | 4 | 3 | true
+        a | b | c || expected
+        4 | 4 | 3 || true
     }
 
     @Ignore
-    def 'First and last sides are equal'() {
+    def "First and last sides are equal"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        4 | 3 | 4 | true
+        a | b | c || expected
+        4 | 3 | 4 || true
     }
 
     @Ignore
-    def 'Equilateral triangles are also isosceles'() {
+    def "Equilateral triangles are also isosceles"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        4 | 4 | 4 | true
+        a | b | c || expected
+        4 | 4 | 4 || true
     }
 
     @Ignore
-    def 'No sides are equal'() {
+    def "No sides are equal for isosceles"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        2 | 3 | 4 | false
+        a | b | c || expected
+        2 | 3 | 4 || false
     }
 
     @Ignore
-    def 'First triangle inequality violation'() {
+    def "First triangle inequality violation"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        1 | 1 | 3 | false
+        a | b | c || expected
+        1 | 1 | 3 || false
     }
 
     @Ignore
-    def 'Second triangle inequality violation'() {
+    def "Second triangle inequality violation"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        1 | 3 | 1 | false
+        a | b | c || expected
+        1 | 3 | 1 || false
     }
 
     @Ignore
-    def 'Third triangle inequality violation'() {
+    def "Third triangle inequality violation"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        3 | 1 | 1 | false
+        a | b | c || expected
+        3 | 1 | 1 || false
     }
 
     @Ignore
-    def 'Sides may be floats'() {
+    def "Sides may be floats for isosceles"() {
         expect:
         Triangle.isIsosceles(a, b, c) == expected
 
         where:
-        a   | b   | c   | expected
-        0.5 | 0.4 | 0.5 | true
+        a   | b   | c   || expected
+        0.5 | 0.4 | 0.5 || true
     }
 
     @Ignore
-    def 'No sides are equal'() {
+    def "No sides are equal for scalene"() {
         expect:
         Triangle.isScalene(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        5 | 4 | 6 | true
+        a | b | c || expected
+        5 | 4 | 6 || true
     }
 
     @Ignore
-    def 'All sides are equal'() {
+    def "All sides are equal for scalene"() {
         expect:
         Triangle.isScalene(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        4 | 4 | 4 | false
+        a | b | c || expected
+        4 | 4 | 4 || false
     }
 
     @Ignore
-    def 'Two sides are equal'() {
+    def "Two sides are equal"() {
         expect:
         Triangle.isScalene(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        4 | 4 | 3 | false
+        a | b | c || expected
+        4 | 4 | 3 || false
     }
 
     @Ignore
-    def 'May not violate triangle inequality'() {
+    def "May not violate triangle inequality"() {
         expect:
         Triangle.isScalene(a, b, c) == expected
 
         where:
-        a | b | c | expected
-        7 | 3 | 2 | false
+        a | b | c || expected
+        7 | 3 | 2 || false
     }
 
     @Ignore
-    def 'Sides may be floats'() {
+    def "Sides may be floats for scalene"() {
         expect:
         Triangle.isScalene(a, b, c) == expected
 
         where:
-        a   | b   | c   | expected
-        0.5 | 0.4 | 0.6 | true
+        a   | b   | c   || expected
+        0.5 | 0.4 | 0.6 || true
     }
 
 }

--- a/exercises/two-fer/src/test/groovy/TwoFerSpec.groovy
+++ b/exercises/two-fer/src/test/groovy/TwoFerSpec.groovy
@@ -2,38 +2,38 @@ import spock.lang.*
 
 class TwoFerSpec extends Specification {
 
-    def 'No name given'() {
+    def "No name given"() {
         expect:
-        TwoFer.twoFer() == "One for you, one for me."
+        TwoFer.twoFer() == 'One for you, one for me.'
     }
 
     @Ignore
-    def 'Empty name given'() {
+    def "Empty name given"() {
         expect:
         TwoFer.twoFer(name) == expected
 
         where:
-        name | expected
-        ""   | "One for you, one for me."
+        name || expected
+        ''   || 'One for you, one for me.'
     }
 
     @Ignore
-    def 'Alice given as a name'() {
+    def "Alice given as a name"() {
         expect:
         TwoFer.twoFer(name) == expected
 
         where:
-        name    | expected
-        "Alice" | "One for Alice, one for me."
+        name    || expected
+        'Alice' || 'One for Alice, one for me.'
     }
 
     @Ignore
-    def 'Bob given as name'() {
+    def "Bob given as name"() {
         expect:
         TwoFer.twoFer(name) == expected
 
         where:
-        name  | expected
-        "Bob" | "One for Bob, one for me."
+        name  || expected
+        'Bob' || 'One for Bob, one for me.'
     }
 }

--- a/exercises/word-count/src/test/groovy/WordCountSpec.groovy
+++ b/exercises/word-count/src/test/groovy/WordCountSpec.groovy
@@ -2,57 +2,57 @@ import spock.lang.*
 
 class WordCountSpec extends Specification {
 
-    def 'Count one word'() {
+    def "Count one word"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence | expected
-        "word"   | ["word": 1]
+        sentence || expected
+        'word'   || ['word': 1]
     }
 
     @Ignore
-    def 'Count one of each'() {
+    def "Count one of each"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence      | expected
-        "one of each" | ["one": 1, "of": 1, "each": 1]
+        sentence      || expected
+        'one of each' || ['one': 1, 'of': 1, 'each': 1]
     }
 
     @Ignore
-    def 'Multiple occurrences of a word'() {
+    def "Multiple occurrences of a word"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                               | expected
-        "one fish two fish red fish blue fish" | ["one": 1, "fish": 4, "two": 1, "red": 1, "blue": 1]
+        sentence                               || expected
+        'one fish two fish red fish blue fish' || ['one': 1, 'fish': 4, 'two': 1, 'red': 1, 'blue': 1]
     }
 
     @Ignore
-    def 'Handles cramped lists'() {
+    def "Handles cramped lists"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence        | expected
-        "one,two,three" | ["one": 1, "two": 1, "three": 1]
+        sentence        || expected
+        'one,two,three' || ['one': 1, 'two': 1, 'three': 1]
     }
 
     @Ignore
-    def 'Handles expanded lists'() {
+    def "Handles expanded lists"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence            | expected
-        "one,\ntwo,\nthree" | ["one": 1, "two": 1, "three": 1]
+        sentence            || expected
+        'one,\ntwo,\nthree' || ['one': 1, 'two': 1, 'three': 1]
     }
 
     @Ignore
-    def 'Count everything only once'() {
+    def "Count everything only once"() {
         when:
         def wordCount = new WordCount(sentence)
 
@@ -64,77 +64,77 @@ class WordCountSpec extends Specification {
         wordCount.wordCount() == expected
 
         where:
-        sentence                                     | expected
-        "all the kings horses and all the kings men" | ["all": 2, "the": 2, "kings": 2, "horses": 1, "and": 1, "men": 1]
+        sentence                                     || expected
+        'all the kings horses and all the kings men' || ['all': 2, 'the': 2, 'kings': 2, 'horses': 1, 'and': 1, 'men': 1]
     }
 
     @Ignore
-    def 'Ignore punctuation'() {
+    def "Ignore punctuation"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                                    | expected
-        'car : carpet as java : javascript!!&@$%^&' | ["car": 1, "carpet": 1, "as": 1, "java": 1, "javascript": 1]
+        sentence                                    || expected
+        'car : carpet as java : javascript!!&@$%^&' || ['car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1]
     }
 
     @Ignore
-    def 'Include numbers'() {
+    def "Include numbers"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                | expected
-        "testing, 1, 2 testing" | ["testing": 2, "1": 1, "2": 1]
+        sentence                || expected
+        'testing, 1, 2 testing' || ['testing': 2, '1': 1, '2': 1]
     }
 
     @Ignore
-    def 'Normalize case'() {
+    def "Normalize case"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence             | expected
-        "go Go GO Stop stop" | ["go": 3, "stop": 2]
+        sentence             || expected
+        'go Go GO Stop stop' || ['go': 3, 'stop': 2]
     }
 
     @Ignore
-    def 'With apostrophes'() {
+    def "With apostrophes"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                               | expected
-        "First: don't laugh. Then: don't cry." | ["first": 1, "don't": 2, "laugh": 1, "then": 1, "cry": 1]
+        sentence                               || expected
+        "First: don't laugh. Then: don't cry." || ['first': 1, "don't": 2, 'laugh': 1, 'then': 1, 'cry': 1]
     }
 
     @Ignore
-    def 'With quotations'() {
+    def "With quotations"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                                    | expected
-        "Joe can't tell between 'large' and large." | ["joe": 1, "can't": 1, "tell": 1, "between": 1, "large": 2, "and": 1]
+        sentence                                    || expected
+        "Joe can't tell between 'large' and large." || ['joe': 1, "can't": 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1]
     }
 
     @Ignore
-    def 'Multiple spaces not detected as a word'() {
+    def "Multiple spaces not detected as a word"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                  | expected
-        " multiple   whitespaces" | ["multiple": 1, "whitespaces": 1]
+        sentence                  || expected
+        ' multiple   whitespaces' || ['multiple': 1, 'whitespaces': 1]
     }
 
     @Ignore
-    def 'Alternating word separators not detected as a word'() {
+    def "Alternating word separators not detected as a word"() {
         expect:
         new WordCount(sentence).wordCount() == expected
 
         where:
-        sentence                     | expected
-        ",\n,one,\n ,two \n 'three'" | ["one": 1, "two": 1, "three": 1]
+        sentence                     || expected
+        ",\n,one,\n ,two \n 'three'" || ['one': 1, 'two': 1, 'three': 1]
     }
 }


### PR DESCRIPTION
Based on issue #154 I have updated the specs to use `||` for the output based on [Spock Framework docs](
http://spockframework.org/spock/docs/1.3/data_driven_testing.html#_syntactic_variations).