### PR TITLE
Upgrade groovy spock gradle

### DIFF
--- a/bin/create_exercise.groovy
+++ b/bin/create_exercise.groovy
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/acronym/build.gradle
+++ b/exercises/acronym/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/allergies/build.gradle
+++ b/exercises/allergies/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/anagram/build.gradle
+++ b/exercises/anagram/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/armstrong-numbers/build.gradle
+++ b/exercises/armstrong-numbers/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/atbash-cipher/build.gradle
+++ b/exercises/atbash-cipher/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/bank-account/build.gradle
+++ b/exercises/bank-account/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/binary-search/build.gradle
+++ b/exercises/binary-search/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/bob/build.gradle
+++ b/exercises/bob/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/collatz-conjecture/build.gradle
+++ b/exercises/collatz-conjecture/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/darts/build.gradle
+++ b/exercises/darts/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/difference-of-squares/build.gradle
+++ b/exercises/difference-of-squares/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/etl/build.gradle
+++ b/exercises/etl/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/flatten-array/build.gradle
+++ b/exercises/flatten-array/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/gigasecond/build.gradle
+++ b/exercises/gigasecond/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/grains/build.gradle
+++ b/exercises/grains/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/hamming/build.gradle
+++ b/exercises/hamming/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/hello-world/build.gradle
+++ b/exercises/hello-world/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/isbn-verifier/build.gradle
+++ b/exercises/isbn-verifier/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/isogram/build.gradle
+++ b/exercises/isogram/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/leap/build.gradle
+++ b/exercises/leap/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/linked-list/build.gradle
+++ b/exercises/linked-list/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/luhn/build.gradle
+++ b/exercises/luhn/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/matching-brackets/build.gradle
+++ b/exercises/matching-brackets/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/matrix/build.gradle
+++ b/exercises/matrix/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/nth-prime/build.gradle
+++ b/exercises/nth-prime/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/nucleotide-count/build.gradle
+++ b/exercises/nucleotide-count/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/pangram/build.gradle
+++ b/exercises/pangram/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/perfect-numbers/build.gradle
+++ b/exercises/perfect-numbers/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/phone-number/build.gradle
+++ b/exercises/phone-number/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/prime-factors/build.gradle
+++ b/exercises/prime-factors/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/protein-translation/build.gradle
+++ b/exercises/protein-translation/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/proverb/build.gradle
+++ b/exercises/proverb/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/raindrops/build.gradle
+++ b/exercises/raindrops/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/resistor-color-duo/build.gradle
+++ b/exercises/resistor-color-duo/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/resistor-color/build.gradle
+++ b/exercises/resistor-color/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/reverse-string/build.gradle
+++ b/exercises/reverse-string/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/rna-transcription/build.gradle
+++ b/exercises/rna-transcription/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/robot-name/build.gradle
+++ b/exercises/robot-name/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/roman-numerals/build.gradle
+++ b/exercises/roman-numerals/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/rotational-cipher/build.gradle
+++ b/exercises/rotational-cipher/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/saddle-points/build.gradle
+++ b/exercises/saddle-points/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/scrabble-score/build.gradle
+++ b/exercises/scrabble-score/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/secret-handshake/build.gradle
+++ b/exercises/secret-handshake/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/series/build.gradle
+++ b/exercises/series/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/space-age/build.gradle
+++ b/exercises/space-age/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/sum-of-multiples/build.gradle
+++ b/exercises/sum-of-multiples/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/triangle/build.gradle
+++ b/exercises/triangle/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/two-fer/build.gradle
+++ b/exercises/two-fer/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/exercises/word-count/build.gradle
+++ b/exercises/word-count/build.gradle
@@ -5,8 +5,8 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
-    compile "org.codehaus.groovy:groovy-all:2.5.6"
+    testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
+    compile "org.codehaus.groovy:groovy-all:2.5.7"
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades,

- [Gradle](https://docs.gradle.org/5.4.1/release-notes.html) from 5.4 to 5.4.1
- Groovy from 2.5.6 to 2.5.7
- Spock from 1.2 to 1.3