### PR TITLE
Robot name is uppercase in the specification.

### DIFF
--- a/exercises/robot-name/src/test/groovy/RobotNameSpec.groovy
+++ b/exercises/robot-name/src/test/groovy/RobotNameSpec.groovy
@@ -4,7 +4,7 @@ class RobotNameSpec extends Specification {
 
     def "Generates a name"() {
         expect:
-        new RobotName().name =~ /^[a-zA-Z]{2}\d{3}$/
+        new RobotName().name =~ /^[A-Z]{2}\d{3}$/
     }
 
     @Ignore


### PR DESCRIPTION
Here we allowed a lowercase name.

Star Wars would get silly if you had C3P0 and c3p0