### PR TITLE
high-scores: new test for non-mutating personalTopThree

### DIFF
--- a/exercises/high-scores/.meta/src/reference/groovy/HighScores.groovy
+++ b/exercises/high-scores/.meta/src/reference/groovy/HighScores.groovy
@@ -14,6 +14,6 @@ class HighScores {
     }
 
     List<Integer> personalTopThree() {
-        scores.sort { -it }.take(3)
+        scores.sort(false) { -it }.take(3)
     }
 }

--- a/exercises/high-scores/src/test/groovy/HighScoresSpec.groovy
+++ b/exercises/high-scores/src/test/groovy/HighScoresSpec.groovy
@@ -80,5 +80,19 @@ class HighScoresSpec extends Specification {
         scores || expected
         [40]   || [40]
     }
+    
+    @Ignore
+    def "Personal top three does not mutate"() {
+        given:
+        def hs = new HighScores(scores)
+        def top3 = hs.personalTopThree()
+
+        expect:
+        hs.latest() == expected
+
+        where:
+        scores           || expected
+        [40, 20, 10, 30] || 30
+    }
 
 }


### PR DESCRIPTION
Add test to ensure the sorting in personalTopThree does not mutate the instance variable containing the list of scores.