### PR TITLE
Adds Groovy 3 and Spock 2 - M2

### DIFF
--- a/bin/create_exercise.groovy
+++ b/bin/create_exercise.groovy
@@ -18,11 +18,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/accumulate/build.gradle
+++ b/exercises/accumulate/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/acronym/build.gradle
+++ b/exercises/acronym/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/all-your-base/build.gradle
+++ b/exercises/all-your-base/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/allergies/build.gradle
+++ b/exercises/allergies/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/anagram/build.gradle
+++ b/exercises/anagram/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/armstrong-numbers/build.gradle
+++ b/exercises/armstrong-numbers/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/atbash-cipher/build.gradle
+++ b/exercises/atbash-cipher/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/bank-account/build.gradle
+++ b/exercises/bank-account/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/binary-search/build.gradle
+++ b/exercises/binary-search/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/bob/build.gradle
+++ b/exercises/bob/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/collatz-conjecture/build.gradle
+++ b/exercises/collatz-conjecture/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/darts/build.gradle
+++ b/exercises/darts/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/difference-of-squares/build.gradle
+++ b/exercises/difference-of-squares/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/etl/build.gradle
+++ b/exercises/etl/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/flatten-array/build.gradle
+++ b/exercises/flatten-array/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/gigasecond/build.gradle
+++ b/exercises/gigasecond/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/grains/build.gradle
+++ b/exercises/grains/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/hamming/build.gradle
+++ b/exercises/hamming/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/hello-world/build.gradle
+++ b/exercises/hello-world/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/high-scores/build.gradle
+++ b/exercises/high-scores/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/isbn-verifier/build.gradle
+++ b/exercises/isbn-verifier/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/isogram/build.gradle
+++ b/exercises/isogram/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/leap/build.gradle
+++ b/exercises/leap/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/linked-list/build.gradle
+++ b/exercises/linked-list/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/luhn/build.gradle
+++ b/exercises/luhn/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/matching-brackets/build.gradle
+++ b/exercises/matching-brackets/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/matrix/build.gradle
+++ b/exercises/matrix/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/nth-prime/build.gradle
+++ b/exercises/nth-prime/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/nucleotide-count/build.gradle
+++ b/exercises/nucleotide-count/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/pangram/build.gradle
+++ b/exercises/pangram/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/perfect-numbers/build.gradle
+++ b/exercises/perfect-numbers/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/phone-number/build.gradle
+++ b/exercises/phone-number/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/prime-factors/build.gradle
+++ b/exercises/prime-factors/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/protein-translation/build.gradle
+++ b/exercises/protein-translation/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/proverb/build.gradle
+++ b/exercises/proverb/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/raindrops/build.gradle
+++ b/exercises/raindrops/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/resistor-color-duo/build.gradle
+++ b/exercises/resistor-color-duo/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/resistor-color-trio/build.gradle
+++ b/exercises/resistor-color-trio/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/resistor-color/build.gradle
+++ b/exercises/resistor-color/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/reverse-string/build.gradle
+++ b/exercises/reverse-string/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/rna-transcription/build.gradle
+++ b/exercises/rna-transcription/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/robot-name/build.gradle
+++ b/exercises/robot-name/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/roman-numerals/build.gradle
+++ b/exercises/roman-numerals/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/rotational-cipher/build.gradle
+++ b/exercises/rotational-cipher/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/run-length-encoding/build.gradle
+++ b/exercises/run-length-encoding/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/saddle-points/build.gradle
+++ b/exercises/saddle-points/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/scrabble-score/build.gradle
+++ b/exercises/scrabble-score/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/secret-handshake/build.gradle
+++ b/exercises/secret-handshake/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/series/build.gradle
+++ b/exercises/series/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/space-age/build.gradle
+++ b/exercises/space-age/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/strain/build.gradle
+++ b/exercises/strain/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/sum-of-multiples/build.gradle
+++ b/exercises/sum-of-multiples/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/triangle/build.gradle
+++ b/exercises/triangle/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/two-fer/build.gradle
+++ b/exercises/two-fer/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]

--- a/exercises/word-count/build.gradle
+++ b/exercises/word-count/build.gradle
@@ -5,11 +5,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
-    implementation "org.codehaus.groovy:groovy-all:2.5.9"
+    testImplementation "org.spockframework:spock-core:2.0-M2-groovy-3.0"
+    implementation "org.codehaus.groovy:groovy-all:3.0.2"
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat = 'full'
         events = ["passed", "failed", "skipped"]


### PR DESCRIPTION
This PR adds back in Groovy 3 with Spock 2 along with the needed `useJUnitPlatform()` pointed out by @artamonovkirill in issue #222. This PR hopefully fixes #222