### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 To help improve this track you can:
 1. check opened issues and help in fixing them: https://github.com/exercism/groovy/issues
 1. add a new exercise to the track (see the information below)

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Groovy](http://www.groovy-lang.org/) is the Apache Foundation's powerful, optionally typed, dynamic language, which also features static-typing and static compilation capabilities.
 
 Groovy is aimed at improving developer productivity thanks to a concise, easy to learn syntax.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Interested in getting started with Groovy, or learning more while you work on exercises?
 
 Try out Groovy with

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Running Tests
 
 Execute the test specification with:


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
