### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "044d9efb-3a21-4df2-bf06-097d8f05a30a",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Groovy locally",
+      "blurb": "Learn how to install Groovy locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "28131ac6-7fc3-4423-92a4-60e9a49a9df5",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Groovy",
+      "blurb": "An overview of how to get started from scratch with Groovy"
+    },
+    {
+      "uuid": "b7540d70-5d84-471c-b335-83154849d55a",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Groovy track",
+      "blurb": "Learn how to test your Groovy exercises on Exercism"
+    },
+    {
+      "uuid": "98315af6-167f-43bb-ab93-8b94a01b708c",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Groovy resources",
+      "blurb": "A collection of useful resources to help you master Groovy"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
