### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -399,7 +399,7 @@
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
-        "uuid": "98ae146a-67f9-49ae-9cd6-00882a374248",
+        "uuid": "ff5f6777-93cb-4211-9dc7-81c44395e673",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -423,7 +423,7 @@
       {
         "slug": "isbn-verifier",
         "name": "Isbn Verifier",
-        "uuid": "c52dfe2b-5634-4c0c-8ea2-3ca86e5d9a33",
+        "uuid": "a528ea39-277c-4a12-b085-6f95e3d7a423",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
