### PR TITLE
🤖 Add stub files to all exercises

### DIFF
--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/main/groovy/Etl.groovy"
+      "src/main/groovy/ETL.groovy"
     ],
     "test": [
-      "src/test/groovy/EtlSpec.groovy"
+      "src/test/groovy/ETLSpec.groovy"
     ],
     "example": [
-      ".meta/src/reference/groovy/Etl.groovy"
+      ".meta/src/reference/groovy/ETL.groovy"
     ]
   },
   "source": "The Jumpstart Lab team",

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/main/groovy/LinkedList.groovy"
+      "src/main/groovy/DoubleLinkedList.groovy"
     ],
     "test": [
-      "src/test/groovy/LinkedListSpec.groovy"
+      "src/test/groovy/DoubleLinkedListSpec.groovy"
     ],
     "example": [
-      ".meta/src/reference/groovy/LinkedList.groovy"
+      ".meta/src/reference/groovy/DoubleLinkedList.groovy"
     ]
   },
   "source": "Classic computer science topic"


### PR DESCRIPTION
In this PR, we created (empty) stub files for all exercises that didn't yet have them.

The lack of stub file generates an unnecessary pain point within Exercism, contributing a significant proportion of support requests, making things more complex for our students, and hindering our ability to automatically run test-suites and provide automated analysis of solutions.

The original discussion for this is at exercism/discussions#238.

**We will automatically merge this PR in two week's time if it has not been merged by track maintainers at that point :slightly_smiling_face:**

## Tracking

https://github.com/exercism/v3-launch/issues/33
