### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -101,7 +101,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "16d2cb93-b903-4c37-9cd0-40096f0fb51c",
         "practices": [],
         "prerequisites": [],
@@ -425,7 +425,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "a528ea39-277c-4a12-b085-6f95e3d7a423",
         "practices": [],
         "prerequisites": [],
@@ -569,7 +569,7 @@
       },
       {
         "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
+        "name": "Sum of Multiples",
         "uuid": "5465d5ca-64b7-4d0d-89cc-048a98daee1d",
         "practices": [],
         "prerequisites": [],
@@ -644,7 +644,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "87d17b76-4cd0-4e15-9f1a-a51907603b6d",
         "practices": [],
         "prerequisites": [],
@@ -686,7 +686,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "5a5accf3-8043-4e5a-90e7-8d6cfd09657c",
         "practices": [],
         "prerequisites": [],
@@ -722,7 +722,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "d7bc4ce7-c2fe-4564-b925-b0d67f7b748f",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579