### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GitHub issues](https://img.shields.io/github/issues/exercism/groovy.svg)](https://github.com/exercism/groovy/issues)
 [![GitHub forks](https://img.shields.io/github/forks/exercism/groovy.svg)](https://github.com/exercism/groovy/network)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/exercism/groovy/master/LICENSE)
-[![Join the chat at https://gitter.im/exercism/groovy](https://badges.gitter.im/exercism/groovy.svg)](https://gitter.im/exercism/groovy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism problems in Groovy
 
@@ -27,5 +26,7 @@ For information on contributing to this track, refer to the [CONTRIBUTING.md](./
 
 ## Support
 
-Need assistance? Check out our Gitter Channel at https://gitter.im/exercism/groovy and ask any questions related to the the track or Groovy language in general.
+Need assistance? Get help on the [Exercism forum][forum].
+
+[forum]: https://forum.exercism.org/
 


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
