### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   validation:
     name: "Validation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -11,7 +11,7 @@ jobs:
     name: "Build"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-12, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.