### PR TITLE
queen-attack solution requires two files

### DIFF
--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -4,12 +4,14 @@
   ],
   "files": {
     "solution": [
+      "src/main/groovy/Queen.groovy",
       "src/main/groovy/QueenAttack.groovy"
     ],
     "test": [
       "src/test/groovy/QueenAttackSpec.groovy"
     ],
     "example": [
+      ".meta/src/reference/groovy/Queen.groovy",
       ".meta/src/reference/groovy/QueenAttack.groovy"
     ]
   },


### PR DESCRIPTION
`exercism submit` (with no args) only picks up one.