### PR TITLE
Fix bug in all-your-base test

### DIFF
--- a/exercises/practice/all-your-base/src/test/groovy/AllYourBaseSpec.groovy
+++ b/exercises/practice/all-your-base/src/test/groovy/AllYourBaseSpec.groovy
@@ -167,7 +167,7 @@ class AllYourBaseSpec extends Specification {
 
         where:
         inputBase | digits | outputBase
-        1         | []     | 10
+        0         | []     | 10
     }
 
     @Ignore


### PR DESCRIPTION
The "Input base 0" test case was incorrectly supplying 1 as input base, this change fixes it.