### PR TITLE
Replace gradle/wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
+      - uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70
   gradle:
     name: "Build"
     strategy:


### PR DESCRIPTION
Suggested by [the gradle/wrapper-validation-action v3.5.0 release notes](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0). 

The SHA for "gradle/actions/wrapper-validation@v3" [is here](https://github.com/gradle/actions/releases/tag/v3.5.0).