### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Build"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612