### PR TITLE
Align class and file names

### DIFF
--- a/exercises/practice/largest-series-product/src/main/groovy/LargestSeriesProduct.groovy
+++ b/exercises/practice/largest-series-product/src/main/groovy/LargestSeriesProduct.groovy
@@ -1,4 +1,4 @@
-class Exercise {
+class LargestSeriesProduct {
     static largestProduct(digits, span) {
         throw new UnsupportedOperationException('Method implementation is missing')
     }


### PR DESCRIPTION
Rename `Exercise` class to `LargestSeriesProduct` (matches file name and the class name expected by the tests