### PR TITLE
[largest-series-product] Align class and file names

### DIFF
--- a/exercises/practice/largest-series-product/.meta/src/reference/groovy/LargestSeriesProduct.groovy
+++ b/exercises/practice/largest-series-product/.meta/src/reference/groovy/LargestSeriesProduct.groovy
@@ -1,4 +1,4 @@
-class Exercise {
+class LargestSeriesProduct {
     static int largestProduct(String digits, final int span) {
         if (span < 0) throw new IllegalArgumentException("span must not be negative")
         if (span > digits.length()) throw new IllegalArgumentException("span must be smaller than string length")

--- a/exercises/practice/largest-series-product/src/main/groovy/LargestSeriesProduct.groovy
+++ b/exercises/practice/largest-series-product/src/main/groovy/LargestSeriesProduct.groovy
@@ -1,4 +1,4 @@
-class Exercise {
+class LargestSeriesProduct {
     static largestProduct(digits, span) {
         throw new UnsupportedOperationException('Method implementation is missing')
     }


### PR DESCRIPTION
Rename the `Exercise` class to `LargestSeriesProduct` (matches the file name and the class name expected by the tests):
- in the stub file
- in reference solution