### PR TITLE
Fix robot-simulator tests in groovy-test-runner

### DIFF
--- a/exercises/practice/robot-simulator/src/test/groovy/RobotSimulatorSpec.groovy
+++ b/exercises/practice/robot-simulator/src/test/groovy/RobotSimulatorSpec.groovy
@@ -1,6 +1,4 @@
-import spock.lang.Ignore
-import spock.lang.Specification
-import spock.lang.Unroll
+import spock.lang.*
 
 class RobotSimulatorSpec extends Specification {
 


### PR DESCRIPTION
Fixes "src/test/groovy/RobotSimulatorSpec.groovy: 5: unable to resolve class Stepwise for annotation":
<img width="452" alt="Screenshot 2024-10-23 at 11 25 34" src="https://github.com/user-attachments/assets/c145c181-2aaa-4e90-bc7e-3f9c92bb4c90">


Since groovy-test-running imports Stepwise annotation, a wild-card or `spock.lang.Stepwise` import is required.
Opted for a wild-card option as this is how it was prior to https://github.com/exercism/groovy/pull/461